### PR TITLE
fix(docker): arranque correcto del stack en modo dev

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,12 +1,15 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
+        env_prefix="FALCONTROL_",
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
+        populate_by_name=True,
     )
 
     # App
@@ -22,12 +25,12 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = 15
     refresh_token_expire_days: int = 7
 
-    # Database
-    postgres_host: str = "db"
-    postgres_port: int = 5432
-    postgres_db: str = "falcontrol"
-    postgres_user: str = "falcontrol"
-    postgres_password: str = "changeme"
+    # Database — no FALCONTROL_ prefix; Docker Compose and the OS use bare POSTGRES_* names
+    postgres_host: str = Field("db", validation_alias="POSTGRES_HOST")
+    postgres_port: int = Field(5432, validation_alias="POSTGRES_PORT")
+    postgres_db: str = Field("falcontrol", validation_alias="POSTGRES_DB")
+    postgres_user: str = Field("falcontrol", validation_alias="POSTGRES_USER")
+    postgres_password: str = Field("changeme", validation_alias="POSTGRES_PASSWORD")
 
     @property
     def database_url(self) -> str:
@@ -43,10 +46,10 @@ class Settings(BaseSettings):
             f"@{self.postgres_host}:{self.postgres_port}/{self.postgres_db}"
         )
 
-    # Redis / Celery
-    redis_host: str = "redis"
-    redis_port: int = 6379
-    redis_db: int = 0
+    # Redis / Celery — no FALCONTROL_ prefix
+    redis_host: str = Field("redis", validation_alias="REDIS_HOST")
+    redis_port: int = Field(6379, validation_alias="REDIS_PORT")
+    redis_db: int = Field(0, validation_alias="REDIS_DB")
 
     @property
     def redis_url(self) -> str:

--- a/backend/app/tasks/celery_app.py
+++ b/backend/app/tasks/celery_app.py
@@ -1,0 +1,19 @@
+from celery import Celery
+
+from app.core.config import settings
+
+celery_app = Celery(
+    "falcontrol",
+    broker=settings.celery_broker_url,
+    backend=settings.celery_result_backend,
+)
+
+celery_app.conf.update(
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    timezone="UTC",
+    enable_utc=True,
+    task_track_started=True,
+    worker_prefetch_multiplier=1,
+)

--- a/backend/app/tasks/jobs.py
+++ b/backend/app/tasks/jobs.py
@@ -1,0 +1,1 @@
+# Ansible job tasks — populated in Sprint 3

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,6 +61,10 @@ strict = true
 plugins = ["pydantic.mypy"]
 exclude = ["alembic/", "tests/"]
 
+[[tool.mypy.overrides]]
+module = ["celery.*", "ansible_runner.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/backend/tests/test_ensure_first_admin.py
+++ b/backend/tests/test_ensure_first_admin.py
@@ -1,0 +1,34 @@
+from app.core.config import settings
+from app.services.auth import verify_password
+from app.services.users import ensure_first_admin, get_user_by_email
+
+
+async def test_ensure_first_admin_creates_admin(db_session) -> None:
+    await ensure_first_admin(db_session)
+    user = await get_user_by_email(db_session, settings.first_admin_email)
+    assert user is not None
+    assert user.role.value == "admin"
+    assert user.is_active is True
+
+
+async def test_ensure_first_admin_password_matches_settings(db_session) -> None:
+    await ensure_first_admin(db_session)
+    user = await get_user_by_email(db_session, settings.first_admin_email)
+    assert user is not None
+    assert verify_password(settings.first_admin_password, user.hashed_password), (
+        "El hash almacenado no verifica contra settings.first_admin_password — "
+        "comprueba que FALCONTROL_FIRST_ADMIN_PASSWORD se lee correctamente"
+    )
+
+
+async def test_ensure_first_admin_is_idempotent(db_session) -> None:
+    await ensure_first_admin(db_session)
+    await ensure_first_admin(db_session)  # segunda llamada no debe crear duplicado
+    from sqlalchemy import func, select
+
+    from app.models.user import User, UserRole
+
+    result = await db_session.execute(
+        select(func.count()).where(User.role == UserRole.admin)
+    )
+    assert result.scalar_one() == 1

--- a/backend/tests/test_ensure_first_admin.py
+++ b/backend/tests/test_ensure_first_admin.py
@@ -28,7 +28,5 @@ async def test_ensure_first_admin_is_idempotent(db_session) -> None:
 
     from app.models.user import User, UserRole
 
-    result = await db_session.execute(
-        select(func.count()).where(User.role == UserRole.admin)
-    )
+    result = await db_session.execute(select(func.count()).where(User.role == UserRole.admin))
     assert result.scalar_one() == 1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,9 +12,11 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: builder
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: "sh -c 'alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload'"
     volumes:
       - ./backend/app:/build/app
+      - ./backend/alembic:/build/alembic
+      - ./backend/alembic.ini:/build/alembic.ini
     ports:
       - "8000:8000"
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,7 +14,7 @@ services:
       target: builder
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     volumes:
-      - ./backend/app:/app/app
+      - ./backend/app:/build/app
     ports:
       - "8000:8000"
     environment:
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfile
       target: builder
     volumes:
-      - ./backend/app:/app/app
+      - ./backend/app:/build/app
     environment:
       FALCONTROL_DEBUG: "true"
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -47,4 +47,4 @@ services:
 
   nginx:
     volumes:
-      - ./deploy/nginx/nginx.dev.conf:/etc/nginx/conf.d/falcontrol.conf:ro
+      - ./deploy/nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     ports:
       - "80:80"
     volumes:
-      - ./deploy/nginx/nginx.conf:/etc/nginx/conf.d/falcontrol.conf:ro
+      - ./deploy/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - frontend
       - backend


### PR DESCRIPTION
## Problemas resueltos

### 1 — `ModuleNotFoundError: No module named 'app'` (uvicorn + celery)
El `builder` stage del Dockerfile tiene `WORKDIR /build`, pero los volúmenes montaban la fuente en `/app/app`. Fix: `./backend/app:/build/app`.

### 2 — `ModuleNotFoundError: No module named 'app.tasks.celery_app'`
El módulo no existía. Creados `celery_app.py` (app Celery mínima), `__init__.py` y `jobs.py` (stub hasta Sprint 3).

### 3 — Página "Welcome to nginx!" en lugar de la app
`nginx:alpine` carga `default.conf` antes que `falcontrol.conf` (orden alfabético). Fix: montar nuestra config directamente sobre `default.conf` en ambos compose files.

### 4 — `alembic upgrade head` no se ejecutaba → `relation "users" does not exist`
El command del backend en dev no lanzaba las migraciones. Fix: `sh -c 'alembic upgrade head && uvicorn ...'` con los volúmenes de `alembic/` y `alembic.ini` montados en `/build/`.

### 5 — `FALCONTROL_FIRST_ADMIN_PASSWORD` ignorado → admin siempre con password `changeme`
Sin `env_prefix`, pydantic-settings buscaba `FIRST_ADMIN_PASSWORD` e ignoraba la variable del `.env`. Fix: `env_prefix="FALCONTROL_"` con `validation_alias` en campos `POSTGRES_*` / `REDIS_*`. Afectaba también a `SECRET_KEY`, `JWT_SECRET`, `DEBUG`, `CORS_ORIGINS`, etc.

## Tests
- 3 tests nuevos para `ensure_first_admin`: creación, hash correcto contra `settings.first_admin_password`, idempotencia
- 14/14 pasan, cobertura 82%
- `ruff + mypy` limpios

🤖 Generated with [Claude Code](https://claude.com/claude-code)