### PR TITLE
feat(sprint-2): CRUD de hosts backend — issue #3

### DIFF
--- a/backend/alembic/versions/0002_create_hosts.py
+++ b/backend/alembic/versions/0002_create_hosts.py
@@ -1,0 +1,56 @@
+"""create hosts table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hosts",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("address", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "os_type",
+            sa.Enum("linux", "windows", name="ostype"),
+            nullable=False,
+        ),
+        sa.Column(
+            "connection_type",
+            sa.Enum("ssh", "winrm", name="connectiontype"),
+            nullable=False,
+        ),
+        sa.Column("port", sa.Integer(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_hosts_name"), "hosts", ["name"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_hosts_name"), table_name="hosts")
+    op.drop_table("hosts")
+    op.execute(sa.text("DROP TYPE IF EXISTS ostype"))
+    op.execute(sa.text("DROP TYPE IF EXISTS connectiontype"))

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,4 +1,5 @@
 from app.api.auth import router as auth_router
+from app.api.hosts import router as hosts_router
 from app.api.users import router as users_router
 
-__all__ = ["auth_router", "users_router"]
+__all__ = ["auth_router", "hosts_router", "users_router"]

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -33,3 +33,12 @@ async def require_admin(current_user: User = Depends(get_current_user)) -> User:
     if current_user.role != UserRole.admin:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
     return current_user
+
+
+async def require_operator_or_admin(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role == UserRole.viewer:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operator or admin access required",
+        )
+    return current_user

--- a/backend/app/api/hosts.py
+++ b/backend/app/api/hosts.py
@@ -1,0 +1,86 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin, require_operator_or_admin
+from app.core.database import get_db
+from app.models.host import Host
+from app.models.user import User
+from app.schemas.host import HostCreate, HostRead, HostUpdate
+from app.services.hosts import (
+    create_host,
+    delete_host,
+    get_host_by_id,
+    get_host_by_name,
+    list_hosts,
+    update_host,
+)
+
+router = APIRouter(prefix="/hosts", tags=["hosts"])
+
+
+@router.get("", response_model=list[HostRead])
+async def get_hosts(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    active_only: bool = Query(default=False),
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> list[Host]:
+    return await list_hosts(db, skip=skip, limit=limit, active_only=active_only)
+
+
+@router.post("", response_model=HostRead, status_code=status.HTTP_201_CREATED)
+async def create_new_host(
+    body: HostCreate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Host:
+    existing = await get_host_by_name(db, body.name)
+    if existing is not None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Host name already exists")
+    return await create_host(db, body)
+
+
+@router.get("/{host_id}", response_model=HostRead)
+async def get_host(
+    host_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> Host:
+    host = await get_host_by_id(db, host_id)
+    if host is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Host not found")
+    return host
+
+
+@router.patch("/{host_id}", response_model=HostRead)
+async def update_existing_host(
+    host_id: uuid.UUID,
+    body: HostUpdate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Host:
+    host = await get_host_by_id(db, host_id)
+    if host is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Host not found")
+    if body.name is not None and body.name != host.name:
+        conflict = await get_host_by_name(db, body.name)
+        if conflict is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Host name already exists"
+            )
+    return await update_host(db, host, body)
+
+
+@router.delete("/{host_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_existing_host(
+    host_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> None:
+    host = await get_host_by_id(db, host_id)
+    if host is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Host not found")
+    await delete_host(db, host)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import auth_router, users_router
+from app.api import auth_router, hosts_router, users_router
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.services.users import ensure_first_admin
@@ -36,6 +36,7 @@ app.add_middleware(
 
 app.include_router(auth_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
+app.include_router(hosts_router, prefix="/api")
 
 
 @app.get("/api/health", tags=["system"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.host import ConnectionType, Host, OsType
 from app.models.user import User, UserRole
 
-__all__ = ["User", "UserRole"]
+__all__ = ["ConnectionType", "Host", "OsType", "User", "UserRole"]

--- a/backend/app/models/host.py
+++ b/backend/app/models/host.py
@@ -1,0 +1,44 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, Enum, Integer, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class OsType(enum.StrEnum):
+    linux = "linux"
+    windows = "windows"
+
+
+class ConnectionType(enum.StrEnum):
+    ssh = "ssh"
+    winrm = "winrm"
+
+
+class Host(Base):
+    __tablename__ = "hosts"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    address: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    os_type: Mapped[OsType] = mapped_column(Enum(OsType, name="ostype"), nullable=False)
+    connection_type: Mapped[ConnectionType] = mapped_column(
+        Enum(ConnectionType, name="connectiontype"), nullable=False
+    )
+    port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<Host id={self.id} name={self.name!r} address={self.address!r}>"

--- a/backend/app/models/host.py
+++ b/backend/app/models/host.py
@@ -31,7 +31,7 @@ class Host(Base):
         Enum(ConnectionType, name="connectiontype"), nullable=False
     )
     port: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    tags: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/schemas/host.py
+++ b/backend/app/schemas/host.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.host import ConnectionType, OsType
+
+
+class HostCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    address: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    os_type: OsType
+    connection_type: ConnectionType
+    port: int | None = Field(default=None, ge=1, le=65535)
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("tags")
+    @classmethod
+    def tags_max_length(cls, v: list[str]) -> list[str]:
+        if len(v) > 20:
+            raise ValueError("Tags list cannot exceed 20 elements")
+        return v
+
+
+class HostRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    address: str
+    description: str | None
+    os_type: OsType
+    connection_type: ConnectionType
+    port: int | None
+    tags: list[str]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime | None
+
+
+class HostUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    address: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    os_type: OsType | None = None
+    connection_type: ConnectionType | None = None
+    port: int | None = Field(default=None, ge=1, le=65535)
+    tags: list[str] | None = None
+    is_active: bool | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def tags_max_length(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None and len(v) > 20:
+            raise ValueError("Tags list cannot exceed 20 elements")
+        return v

--- a/backend/app/services/hosts.py
+++ b/backend/app/services/hosts.py
@@ -1,0 +1,52 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.host import Host
+from app.schemas.host import HostCreate, HostUpdate
+
+
+async def get_host_by_id(db: AsyncSession, host_id: uuid.UUID) -> Host | None:
+    result = await db.execute(select(Host).where(Host.id == host_id))
+    return result.scalar_one_or_none()
+
+
+async def get_host_by_name(db: AsyncSession, name: str) -> Host | None:
+    result = await db.execute(select(Host).where(Host.name == name))
+    return result.scalar_one_or_none()
+
+
+async def list_hosts(
+    db: AsyncSession,
+    skip: int = 0,
+    limit: int = 100,
+    active_only: bool = False,
+) -> list[Host]:
+    query = select(Host)
+    if active_only:
+        query = query.where(Host.is_active.is_(True))
+    query = query.order_by(Host.name).offset(skip).limit(limit)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def create_host(db: AsyncSession, data: HostCreate) -> Host:
+    host = Host(**data.model_dump())
+    db.add(host)
+    await db.commit()
+    await db.refresh(host)
+    return host
+
+
+async def update_host(db: AsyncSession, host: Host, data: HostUpdate) -> Host:
+    for field, value in data.model_dump(exclude_unset=True).items():
+        setattr(host, field, value)
+    await db.commit()
+    await db.refresh(host)
+    return host
+
+
+async def delete_host(db: AsyncSession, host: Host) -> None:
+    await db.delete(host)
+    await db.commit()

--- a/backend/tests/test_hosts.py
+++ b/backend/tests/test_hosts.py
@@ -89,16 +89,22 @@ async def test_list_hosts_requires_auth(client: AsyncClient) -> None:
 
 
 async def test_list_hosts_active_only_filter(client: AsyncClient, admin_token: str) -> None:
-    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     payload2 = {**HOST_PAYLOAD, "name": "web-02", "address": "192.168.1.11"}
-    created = await client.post("/api/hosts", json=payload2, headers={"Authorization": f"Bearer {admin_token}"})
+    created = await client.post(
+        "/api/hosts", json=payload2, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
     await client.patch(
         f"/api/hosts/{host_id}",
         json={"is_active": False},
         headers={"Authorization": f"Bearer {admin_token}"},
     )
-    resp = await client.get("/api/hosts?active_only=true", headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.get(
+        "/api/hosts?active_only=true", headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 200
     names = [h["name"] for h in resp.json()]
     assert "web-01" in names
@@ -145,8 +151,12 @@ async def test_create_host_as_viewer_forbidden(client: AsyncClient, viewer_token
 
 
 async def test_create_host_duplicate_name(client: AsyncClient, admin_token: str) -> None:
-    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
-    resp = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    resp = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 409
 
 
@@ -157,13 +167,17 @@ async def test_create_host_without_auth(client: AsyncClient) -> None:
 
 async def test_create_host_invalid_port(client: AsyncClient, admin_token: str) -> None:
     payload = {**HOST_PAYLOAD, "port": 99999}
-    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.post(
+        "/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 422
 
 
 async def test_create_host_too_many_tags(client: AsyncClient, admin_token: str) -> None:
     payload = {**HOST_PAYLOAD, "tags": [f"tag{i}" for i in range(21)]}
-    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.post(
+        "/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 422
 
 
@@ -175,14 +189,23 @@ async def test_create_host_windows_winrm(client: AsyncClient, admin_token: str) 
         "connection_type": "winrm",
         "port": 5985,
     }
-    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.post(
+        "/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 201
     assert resp.json()["connection_type"] == "winrm"
 
 
 async def test_create_host_optional_fields_default(client: AsyncClient, admin_token: str) -> None:
-    payload = {"name": "minimal-host", "address": "10.0.0.1", "os_type": "linux", "connection_type": "ssh"}
-    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    payload = {
+        "name": "minimal-host",
+        "address": "10.0.0.1",
+        "os_type": "linux",
+        "connection_type": "ssh",
+    }
+    resp = await client.post(
+        "/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 201
     body = resp.json()
     assert body["port"] is None
@@ -194,9 +217,13 @@ async def test_create_host_optional_fields_default(client: AsyncClient, admin_to
 
 
 async def test_get_host_by_id(client: AsyncClient, admin_token: str) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
-    resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.get(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 200
     assert resp.json()["id"] == host_id
 
@@ -209,10 +236,16 @@ async def test_get_host_not_found(client: AsyncClient, admin_token: str) -> None
     assert resp.status_code == 404
 
 
-async def test_get_host_viewer_can_read(client: AsyncClient, admin_token: str, viewer_token: str) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+async def test_get_host_viewer_can_read(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
-    resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {viewer_token}"})
+    resp = await client.get(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {viewer_token}"}
+    )
     assert resp.status_code == 200
 
 
@@ -220,7 +253,9 @@ async def test_get_host_viewer_can_read(client: AsyncClient, admin_token: str, v
 
 
 async def test_patch_host_name_and_tags(client: AsyncClient, admin_token: str) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
     resp = await client.patch(
         f"/api/hosts/{host_id}",
@@ -244,9 +279,13 @@ async def test_patch_host_not_found(client: AsyncClient, admin_token: str) -> No
 
 
 async def test_patch_host_duplicate_name(client: AsyncClient, admin_token: str) -> None:
-    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     p2 = {**HOST_PAYLOAD, "name": "web-02", "address": "192.168.1.11"}
-    created2 = await client.post("/api/hosts", json=p2, headers={"Authorization": f"Bearer {admin_token}"})
+    created2 = await client.post(
+        "/api/hosts", json=p2, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host2_id = created2.json()["id"]
     resp = await client.patch(
         f"/api/hosts/{host2_id}",
@@ -256,8 +295,12 @@ async def test_patch_host_duplicate_name(client: AsyncClient, admin_token: str) 
     assert resp.status_code == 409
 
 
-async def test_patch_host_viewer_forbidden(client: AsyncClient, admin_token: str, viewer_token: str) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+async def test_patch_host_viewer_forbidden(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
     resp = await client.patch(
         f"/api/hosts/{host_id}",
@@ -271,20 +314,30 @@ async def test_patch_host_viewer_forbidden(client: AsyncClient, admin_token: str
 
 
 async def test_delete_host_as_admin(client: AsyncClient, admin_token: str) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
-    resp = await client.delete(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.delete(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert resp.status_code == 204
-    get_resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    get_resp = await client.get(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
     assert get_resp.status_code == 404
 
 
 async def test_delete_host_as_operator_forbidden(
     client: AsyncClient, admin_token: str, operator_token: str
 ) -> None:
-    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    created = await client.post(
+        "/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"}
+    )
     host_id = created.json()["id"]
-    resp = await client.delete(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {operator_token}"})
+    resp = await client.delete(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {operator_token}"}
+    )
     assert resp.status_code == 403
 
 

--- a/backend/tests/test_hosts.py
+++ b/backend/tests/test_hosts.py
@@ -1,0 +1,296 @@
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.user import UserCreate
+from app.services.users import create_user
+
+HOST_PAYLOAD = {
+    "name": "web-01",
+    "address": "192.168.1.10",
+    "os_type": "linux",
+    "connection_type": "ssh",
+    "port": 22,
+    "tags": ["production", "web"],
+}
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@test.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def operator_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="operator@test.com", password="operatorpass1", role=UserRole.operator),
+        role=UserRole.operator,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@test.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@test.com", "adminpass1")
+
+
+@pytest.fixture
+async def operator_token(client: AsyncClient, operator_user) -> str:
+    return await _login(client, "operator@test.com", "operatorpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@test.com", "viewerpass1")
+
+
+# --- GET /api/hosts ---
+
+
+async def test_list_hosts_empty(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/hosts", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_hosts_returns_created(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/hosts",
+        json=HOST_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.get("/api/hosts", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]["name"] == "web-01"
+
+
+async def test_list_hosts_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/hosts")
+    assert resp.status_code == 401
+
+
+async def test_list_hosts_active_only_filter(client: AsyncClient, admin_token: str) -> None:
+    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    payload2 = {**HOST_PAYLOAD, "name": "web-02", "address": "192.168.1.11"}
+    created = await client.post("/api/hosts", json=payload2, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    await client.patch(
+        f"/api/hosts/{host_id}",
+        json={"is_active": False},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.get("/api/hosts?active_only=true", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    names = [h["name"] for h in resp.json()]
+    assert "web-01" in names
+    assert "web-02" not in names
+
+
+# --- POST /api/hosts ---
+
+
+async def test_create_host_as_admin(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.post(
+        "/api/hosts",
+        json=HOST_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "web-01"
+    assert body["os_type"] == "linux"
+    assert body["connection_type"] == "ssh"
+    assert body["port"] == 22
+    assert body["tags"] == ["production", "web"]
+    assert body["is_active"] is True
+    assert "id" in body
+    assert "created_at" in body
+
+
+async def test_create_host_as_operator(client: AsyncClient, operator_token: str) -> None:
+    resp = await client.post(
+        "/api/hosts",
+        json=HOST_PAYLOAD,
+        headers={"Authorization": f"Bearer {operator_token}"},
+    )
+    assert resp.status_code == 201
+
+
+async def test_create_host_as_viewer_forbidden(client: AsyncClient, viewer_token: str) -> None:
+    resp = await client.post(
+        "/api/hosts",
+        json=HOST_PAYLOAD,
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_create_host_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    resp = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 409
+
+
+async def test_create_host_without_auth(client: AsyncClient) -> None:
+    resp = await client.post("/api/hosts", json=HOST_PAYLOAD)
+    assert resp.status_code == 401
+
+
+async def test_create_host_invalid_port(client: AsyncClient, admin_token: str) -> None:
+    payload = {**HOST_PAYLOAD, "port": 99999}
+    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 422
+
+
+async def test_create_host_too_many_tags(client: AsyncClient, admin_token: str) -> None:
+    payload = {**HOST_PAYLOAD, "tags": [f"tag{i}" for i in range(21)]}
+    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 422
+
+
+async def test_create_host_windows_winrm(client: AsyncClient, admin_token: str) -> None:
+    payload = {
+        "name": "win-srv-01",
+        "address": "192.168.1.50",
+        "os_type": "windows",
+        "connection_type": "winrm",
+        "port": 5985,
+    }
+    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 201
+    assert resp.json()["connection_type"] == "winrm"
+
+
+async def test_create_host_optional_fields_default(client: AsyncClient, admin_token: str) -> None:
+    payload = {"name": "minimal-host", "address": "10.0.0.1", "os_type": "linux", "connection_type": "ssh"}
+    resp = await client.post("/api/hosts", json=payload, headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["port"] is None
+    assert body["tags"] == []
+    assert body["description"] is None
+
+
+# --- GET /api/hosts/{id} ---
+
+
+async def test_get_host_by_id(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == host_id
+
+
+async def test_get_host_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get(
+        "/api/hosts/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_get_host_viewer_can_read(client: AsyncClient, admin_token: str, viewer_token: str) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {viewer_token}"})
+    assert resp.status_code == 200
+
+
+# --- PATCH /api/hosts/{id} ---
+
+
+async def test_patch_host_name_and_tags(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/hosts/{host_id}",
+        json={"name": "web-01-renamed", "tags": ["staging"]},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "web-01-renamed"
+    assert body["tags"] == ["staging"]
+    assert body["address"] == "192.168.1.10"
+
+
+async def test_patch_host_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.patch(
+        "/api/hosts/00000000-0000-0000-0000-000000000000",
+        json={"name": "ghost"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_patch_host_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    p2 = {**HOST_PAYLOAD, "name": "web-02", "address": "192.168.1.11"}
+    created2 = await client.post("/api/hosts", json=p2, headers={"Authorization": f"Bearer {admin_token}"})
+    host2_id = created2.json()["id"]
+    resp = await client.patch(
+        f"/api/hosts/{host2_id}",
+        json={"name": "web-01"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_patch_host_viewer_forbidden(client: AsyncClient, admin_token: str, viewer_token: str) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/hosts/{host_id}",
+        json={"name": "hacked"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- DELETE /api/hosts/{id} ---
+
+
+async def test_delete_host_as_admin(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.delete(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 204
+    get_resp = await client.get(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"})
+    assert get_resp.status_code == 404
+
+
+async def test_delete_host_as_operator_forbidden(
+    client: AsyncClient, admin_token: str, operator_token: str
+) -> None:
+    created = await client.post("/api/hosts", json=HOST_PAYLOAD, headers={"Authorization": f"Bearer {admin_token}"})
+    host_id = created.json()["id"]
+    resp = await client.delete(f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {operator_token}"})
+    assert resp.status_code == 403
+
+
+async def test_delete_host_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.delete(
+        "/api/hosts/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Resumen

- Modelo SQLAlchemy `Host` con enums `OsType` / `ConnectionType`, campo `tags` JSON y timestamps `created_at` / `updated_at`
- Schemas Pydantic v2: `HostCreate`, `HostRead`, `HostUpdate` con validación de port (1-65535) y tags (máx 20)
- Servicio `services/hosts.py`: list con paginación + `active_only`, PATCH semántico con `exclude_unset`
- Router `/api/hosts`: GET (cualquier usuario auth), POST/PATCH (operator+), DELETE (solo admin)
- Dep `require_operator_or_admin` añadida a `deps.py` — reutilizable para issues #4 y #5
- Migración Alembic `0002_create_hosts.py` encadenada a la migración de usuarios

## Tests

- 23 tests de integración en `tests/test_hosts.py` — todos verdes
- Suite completa: 37/37 pasados
- Cobertura total: 82% (≥ 70% requerido en `services/` y `api/`)

## Plan de commits

1. `feat(models)`: Host model
2. `feat(schemas)`: HostCreate, HostRead, HostUpdate
3. `feat(services)`: hosts.py CRUD
4. `feat(api)`: /api/hosts router
5. `feat(db)`: migración Alembic 0002
6. `test`: integración CRUD /api/hosts

Cierra #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)