### PR TITLE
feat(sprint-2): CRUD de inventarios backend — issue #4

### DIFF
--- a/backend/alembic/versions/0003_create_inventories.py
+++ b/backend/alembic/versions/0003_create_inventories.py
@@ -1,0 +1,50 @@
+"""create inventories and inventory_hosts tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-04-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0003"
+down_revision: str | None = "0002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "inventories",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_inventories_name"), "inventories", ["name"], unique=True)
+
+    op.create_table(
+        "inventory_hosts",
+        sa.Column("inventory_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("host_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["host_id"], ["hosts.id"]),
+        sa.ForeignKeyConstraint(["inventory_id"], ["inventories.id"]),
+        sa.PrimaryKeyConstraint("inventory_id", "host_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("inventory_hosts")
+    op.drop_index(op.f("ix_inventories_name"), table_name="inventories")
+    op.drop_table("inventories")

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,6 @@
 from app.api.auth import router as auth_router
 from app.api.hosts import router as hosts_router
+from app.api.inventories import router as inventories_router
 from app.api.users import router as users_router
 
-__all__ = ["auth_router", "hosts_router", "users_router"]
+__all__ = ["auth_router", "hosts_router", "inventories_router", "users_router"]

--- a/backend/app/api/inventories.py
+++ b/backend/app/api/inventories.py
@@ -1,0 +1,87 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin, require_operator_or_admin
+from app.core.database import get_db
+from app.models.inventory import Inventory
+from app.models.user import User
+from app.schemas.inventory import InventoryCreate, InventoryRead, InventoryUpdate
+from app.services.inventories import (
+    create_inventory,
+    delete_inventory,
+    get_inventory_by_id,
+    get_inventory_by_name,
+    list_inventories,
+    update_inventory,
+)
+
+router = APIRouter(prefix="/inventories", tags=["inventories"])
+
+
+@router.get("", response_model=list[InventoryRead])
+async def get_inventories(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> list[Inventory]:
+    return await list_inventories(db, skip=skip, limit=limit)
+
+
+@router.post("", response_model=InventoryRead, status_code=status.HTTP_201_CREATED)
+async def create_new_inventory(
+    body: InventoryCreate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Inventory:
+    existing = await get_inventory_by_name(db, body.name)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Inventory name already exists"
+        )
+    return await create_inventory(db, body)
+
+
+@router.get("/{inventory_id}", response_model=InventoryRead)
+async def get_inventory(
+    inventory_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> Inventory:
+    inventory = await get_inventory_by_id(db, inventory_id)
+    if inventory is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Inventory not found")
+    return inventory
+
+
+@router.patch("/{inventory_id}", response_model=InventoryRead)
+async def update_existing_inventory(
+    inventory_id: uuid.UUID,
+    body: InventoryUpdate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Inventory:
+    inventory = await get_inventory_by_id(db, inventory_id)
+    if inventory is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Inventory not found")
+    if body.name is not None and body.name != inventory.name:
+        conflict = await get_inventory_by_name(db, body.name)
+        if conflict is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Inventory name already exists"
+            )
+    return await update_inventory(db, inventory, body)
+
+
+@router.delete("/{inventory_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_existing_inventory(
+    inventory_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> None:
+    inventory = await get_inventory_by_id(db, inventory_id)
+    if inventory is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Inventory not found")
+    await delete_inventory(db, inventory)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import auth_router, hosts_router, users_router
+from app.api import auth_router, hosts_router, inventories_router, users_router
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.services.users import ensure_first_admin
@@ -37,6 +37,7 @@ app.add_middleware(
 app.include_router(auth_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(hosts_router, prefix="/api")
+app.include_router(inventories_router, prefix="/api")
 
 
 @app.get("/api/health", tags=["system"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.host import ConnectionType, Host, OsType
+from app.models.inventory import Inventory, inventory_hosts
 from app.models.user import User, UserRole
 
-__all__ = ["ConnectionType", "Host", "OsType", "User", "UserRole"]
+__all__ = ["ConnectionType", "Host", "Inventory", "OsType", "User", "UserRole", "inventory_hosts"]

--- a/backend/app/models/inventory.py
+++ b/backend/app/models/inventory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Table, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.host import Host
+
+inventory_hosts = Table(
+    "inventory_hosts",
+    Base.metadata,
+    Column("inventory_id", Uuid(as_uuid=True), ForeignKey("inventories.id"), primary_key=True),
+    Column("host_id", Uuid(as_uuid=True), ForeignKey("hosts.id"), primary_key=True),
+)
+
+
+class Inventory(Base):
+    __tablename__ = "inventories"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    hosts: Mapped[list[Host]] = relationship("Host", secondary=inventory_hosts, lazy="selectin")
+
+    def __repr__(self) -> str:
+        return f"<Inventory id={self.id} name={self.name!r}>"

--- a/backend/app/schemas/inventory.py
+++ b/backend/app/schemas/inventory.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.host import HostRead
+
+
+class InventoryCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    host_ids: list[uuid.UUID] = Field(default_factory=list)
+
+
+class InventoryRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    description: str | None
+    hosts: list[HostRead]
+    created_at: datetime
+    updated_at: datetime | None
+
+
+class InventoryUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    host_ids: list[uuid.UUID] | None = None

--- a/backend/app/services/inventories.py
+++ b/backend/app/services/inventories.py
@@ -1,0 +1,60 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.host import Host
+from app.models.inventory import Inventory
+from app.schemas.inventory import InventoryCreate, InventoryUpdate
+
+
+async def _resolve_hosts(db: AsyncSession, host_ids: list[uuid.UUID]) -> list[Host]:
+    if not host_ids:
+        return []
+    result = await db.execute(select(Host).where(Host.id.in_(host_ids)))
+    return list(result.scalars().all())
+
+
+async def get_inventory_by_id(db: AsyncSession, inventory_id: uuid.UUID) -> Inventory | None:
+    result = await db.execute(select(Inventory).where(Inventory.id == inventory_id))
+    return result.scalar_one_or_none()
+
+
+async def get_inventory_by_name(db: AsyncSession, name: str) -> Inventory | None:
+    result = await db.execute(select(Inventory).where(Inventory.name == name))
+    return result.scalar_one_or_none()
+
+
+async def list_inventories(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[Inventory]:
+    result = await db.execute(
+        select(Inventory).order_by(Inventory.name).offset(skip).limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def create_inventory(db: AsyncSession, data: InventoryCreate) -> Inventory:
+    hosts = await _resolve_hosts(db, data.host_ids)
+    inventory = Inventory(name=data.name, description=data.description, hosts=hosts)
+    db.add(inventory)
+    await db.commit()
+    await db.refresh(inventory)
+    return inventory
+
+
+async def update_inventory(
+    db: AsyncSession, inventory: Inventory, data: InventoryUpdate
+) -> Inventory:
+    if data.name is not None:
+        inventory.name = data.name
+    if data.description is not None:
+        inventory.description = data.description
+    if data.host_ids is not None:
+        inventory.hosts = await _resolve_hosts(db, data.host_ids)
+    await db.commit()
+    await db.refresh(inventory)
+    return inventory
+
+
+async def delete_inventory(db: AsyncSession, inventory: Inventory) -> None:
+    await db.delete(inventory)
+    await db.commit()

--- a/backend/app/services/inventories.py
+++ b/backend/app/services/inventories.py
@@ -26,9 +26,7 @@ async def get_inventory_by_name(db: AsyncSession, name: str) -> Inventory | None
 
 
 async def list_inventories(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[Inventory]:
-    result = await db.execute(
-        select(Inventory).order_by(Inventory.name).offset(skip).limit(limit)
-    )
+    result = await db.execute(select(Inventory).order_by(Inventory.name).offset(skip).limit(limit))
     return list(result.scalars().all())
 
 

--- a/backend/tests/test_inventories.py
+++ b/backend/tests/test_inventories.py
@@ -1,0 +1,372 @@
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.host import HostCreate
+from app.schemas.user import UserCreate
+from app.services.hosts import create_host
+from app.services.users import create_user
+
+INVENTORY_PAYLOAD = {"name": "prod-servers", "description": "Servidores de producción"}
+
+HOST_DATA = {
+    "name": "web-01",
+    "address": "192.168.1.10",
+    "os_type": "linux",
+    "connection_type": "ssh",
+}
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@test.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def operator_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="operator@test.com", password="operatorpass1", role=UserRole.operator),
+        role=UserRole.operator,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@test.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@test.com", "adminpass1")
+
+
+@pytest.fixture
+async def operator_token(client: AsyncClient, operator_user) -> str:
+    return await _login(client, "operator@test.com", "operatorpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@test.com", "viewerpass1")
+
+
+@pytest.fixture
+async def host_id(db_session) -> str:
+    host = await create_host(db_session, HostCreate(**HOST_DATA))
+    return str(host.id)
+
+
+# --- GET /api/inventories ---
+
+
+async def test_list_inventories_empty(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/inventories", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_inventories_returns_created(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.get("/api/inventories", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+    assert resp.json()[0]["name"] == "prod-servers"
+
+
+async def test_list_inventories_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/inventories")
+    assert resp.status_code == 401
+
+
+# --- POST /api/inventories ---
+
+
+async def test_create_inventory_as_admin(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "prod-servers"
+    assert body["description"] == "Servidores de producción"
+    assert body["hosts"] == []
+    assert "id" in body
+    assert "created_at" in body
+
+
+async def test_create_inventory_as_operator(client: AsyncClient, operator_token: str) -> None:
+    resp = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {operator_token}"},
+    )
+    assert resp.status_code == 201
+
+
+async def test_create_inventory_as_viewer_forbidden(client: AsyncClient, viewer_token: str) -> None:
+    resp = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_create_inventory_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_create_inventory_without_auth(client: AsyncClient) -> None:
+    resp = await client.post("/api/inventories", json=INVENTORY_PAYLOAD)
+    assert resp.status_code == 401
+
+
+async def test_create_inventory_with_hosts(
+    client: AsyncClient, admin_token: str, host_id: str
+) -> None:
+    payload = {**INVENTORY_PAYLOAD, "host_ids": [host_id]}
+    resp = await client.post(
+        "/api/inventories",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert len(body["hosts"]) == 1
+    assert body["hosts"][0]["id"] == host_id
+
+
+async def test_create_inventory_ignores_unknown_host_ids(
+    client: AsyncClient, admin_token: str
+) -> None:
+    payload = {**INVENTORY_PAYLOAD, "host_ids": ["00000000-0000-0000-0000-000000000000"]}
+    resp = await client.post(
+        "/api/inventories",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["hosts"] == []
+
+
+# --- GET /api/inventories/{id} ---
+
+
+async def test_get_inventory_by_id(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == inv_id
+
+
+async def test_get_inventory_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get(
+        "/api/inventories/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_get_inventory_viewer_can_read(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {viewer_token}"}
+    )
+    assert resp.status_code == 200
+
+
+# --- PATCH /api/inventories/{id} ---
+
+
+async def test_patch_inventory_name(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/inventories/{inv_id}",
+        json={"name": "staging-servers"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "staging-servers"
+    assert resp.json()["description"] == "Servidores de producción"
+
+
+async def test_patch_inventory_replace_hosts(
+    client: AsyncClient, admin_token: str, host_id: str
+) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/inventories/{inv_id}",
+        json={"host_ids": [host_id]},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["hosts"]) == 1
+    resp2 = await client.patch(
+        f"/api/inventories/{inv_id}",
+        json={"host_ids": []},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["hosts"] == []
+
+
+async def test_patch_inventory_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.patch(
+        "/api/inventories/00000000-0000-0000-0000-000000000000",
+        json={"name": "ghost"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_patch_inventory_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv2 = await client.post(
+        "/api/inventories",
+        json={"name": "staging-servers"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv2_id = inv2.json()["id"]
+    resp = await client.patch(
+        f"/api/inventories/{inv2_id}",
+        json={"name": "prod-servers"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_patch_inventory_viewer_forbidden(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/inventories/{inv_id}",
+        json={"name": "hacked"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- DELETE /api/inventories/{id} ---
+
+
+async def test_delete_inventory_as_admin(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 204
+    get_resp = await client.get(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert get_resp.status_code == 404
+
+
+async def test_delete_inventory_as_operator_forbidden(
+    client: AsyncClient, admin_token: str, operator_token: str
+) -> None:
+    created = await client.post(
+        "/api/inventories",
+        json=INVENTORY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {operator_token}"}
+    )
+    assert resp.status_code == 403
+
+
+async def test_delete_inventory_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.delete(
+        "/api/inventories/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_delete_inventory_does_not_delete_hosts(
+    client: AsyncClient, admin_token: str, host_id: str
+) -> None:
+    payload = {**INVENTORY_PAYLOAD, "host_ids": [host_id]}
+    created = await client.post(
+        "/api/inventories",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    inv_id = created.json()["id"]
+    await client.delete(
+        f"/api/inventories/{inv_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    host_resp = await client.get(
+        f"/api/hosts/{host_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert host_resp.status_code == 200


### PR DESCRIPTION
## Resumen

- Modelo `Inventory` con relación M:N a `Host` via tabla de asociación `inventory_hosts`; `lazy="selectin"` para evitar N+1
- Schemas Pydantic v2: `InventoryCreate`, `InventoryRead`, `InventoryUpdate`; `host_ids` en Create/Update gestiona la asignación de hosts
- Servicio `services/inventories.py`: `_resolve_hosts` hace un único `IN` query para resolver ids; PATCH reemplaza la lista completa cuando `host_ids` no es `None`
- Router `/api/inventories`: mismos permisos que hosts (GET any auth, POST/PATCH operator+, DELETE admin)
- Migración Alembic `0003_create_inventories.py` encadenada a `0002`

## Tests

- 22 tests de integración — todos verdes
- Suite completa: 59/59 pasados
- Cobertura total: 81%
- Incluye test que verifica que borrar un inventario no borra los hosts asociados

## Commits

1. `feat(models)`: Inventory + tabla M:N inventory_hosts
2. `feat(schemas)`: InventoryCreate, InventoryRead, InventoryUpdate
3. `feat(services)`: inventories.py CRUD
4. `feat(api)`: /api/inventories router
5. `feat(db)`: migración Alembic 0003
6. `test`: integración CRUD /api/inventories

Cierra #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)