### PR TITLE
feat(sprint-2): credenciales cifradas con Fernet — issue #5

### DIFF
--- a/backend/alembic/versions/0004_create_credentials.py
+++ b/backend/alembic/versions/0004_create_credentials.py
@@ -1,0 +1,49 @@
+"""create credentials table
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-04-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0004"
+down_revision: str | None = "0003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credentials",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column(
+            "credential_type",
+            sa.Enum("ssh_key", "ssh_password", "winrm", name="credentialtype"),
+            nullable=False,
+        ),
+        sa.Column("username", sa.String(255), nullable=True),
+        sa.Column("encrypted_secret", sa.Text(), nullable=False),
+        sa.Column("encrypted_passphrase", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_credentials_name"), "credentials", ["name"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_credentials_name"), table_name="credentials")
+    op.drop_table("credentials")
+    op.execute(sa.text("DROP TYPE IF EXISTS credentialtype"))

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,13 @@
 from app.api.auth import router as auth_router
+from app.api.credentials import router as credentials_router
 from app.api.hosts import router as hosts_router
 from app.api.inventories import router as inventories_router
 from app.api.users import router as users_router
 
-__all__ = ["auth_router", "hosts_router", "inventories_router", "users_router"]
+__all__ = [
+    "auth_router",
+    "credentials_router",
+    "hosts_router",
+    "inventories_router",
+    "users_router",
+]

--- a/backend/app/api/credentials.py
+++ b/backend/app/api/credentials.py
@@ -1,0 +1,87 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin, require_operator_or_admin
+from app.core.database import get_db
+from app.models.credential import Credential
+from app.models.user import User
+from app.schemas.credential import CredentialCreate, CredentialRead, CredentialUpdate
+from app.services.credentials import (
+    create_credential,
+    delete_credential,
+    get_credential_by_id,
+    get_credential_by_name,
+    list_credentials,
+    update_credential,
+)
+
+router = APIRouter(prefix="/credentials", tags=["credentials"])
+
+
+@router.get("", response_model=list[CredentialRead])
+async def get_credentials(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> list[Credential]:
+    return await list_credentials(db, skip=skip, limit=limit)
+
+
+@router.post("", response_model=CredentialRead, status_code=status.HTTP_201_CREATED)
+async def create_new_credential(
+    body: CredentialCreate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Credential:
+    existing = await get_credential_by_name(db, body.name)
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Credential name already exists"
+        )
+    return await create_credential(db, body)
+
+
+@router.get("/{credential_id}", response_model=CredentialRead)
+async def get_credential(
+    credential_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(get_current_user),
+) -> Credential:
+    credential = await get_credential_by_id(db, credential_id)
+    if credential is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+    return credential
+
+
+@router.patch("/{credential_id}", response_model=CredentialRead)
+async def update_existing_credential(
+    credential_id: uuid.UUID,
+    body: CredentialUpdate,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(require_operator_or_admin),
+) -> Credential:
+    credential = await get_credential_by_id(db, credential_id)
+    if credential is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+    if body.name is not None and body.name != credential.name:
+        conflict = await get_credential_by_name(db, body.name)
+        if conflict is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Credential name already exists"
+            )
+    return await update_credential(db, credential, body)
+
+
+@router.delete("/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_existing_credential(
+    credential_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+) -> None:
+    credential = await get_credential_by_id(db, credential_id)
+    if credential is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Credential not found")
+    await delete_credential(db, credential)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import auth_router, hosts_router, inventories_router, users_router
+from app.api import auth_router, credentials_router, hosts_router, inventories_router, users_router
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.services.users import ensure_first_admin
@@ -38,6 +38,7 @@ app.include_router(auth_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(hosts_router, prefix="/api")
 app.include_router(inventories_router, prefix="/api")
+app.include_router(credentials_router, prefix="/api")
 
 
 @app.get("/api/health", tags=["system"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,16 @@
+from app.models.credential import Credential, CredentialType
 from app.models.host import ConnectionType, Host, OsType
 from app.models.inventory import Inventory, inventory_hosts
 from app.models.user import User, UserRole
 
-__all__ = ["ConnectionType", "Host", "Inventory", "OsType", "User", "UserRole", "inventory_hosts"]
+__all__ = [
+    "ConnectionType",
+    "Credential",
+    "CredentialType",
+    "Host",
+    "Inventory",
+    "OsType",
+    "User",
+    "UserRole",
+    "inventory_hosts",
+]

--- a/backend/app/models/credential.py
+++ b/backend/app/models/credential.py
@@ -1,0 +1,38 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, String, Text, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class CredentialType(enum.StrEnum):
+    ssh_key = "ssh_key"
+    ssh_password = "ssh_password"
+    winrm = "winrm"
+
+
+class Credential(Base):
+    __tablename__ = "credentials"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    credential_type: Mapped[CredentialType] = mapped_column(
+        Enum(CredentialType, name="credentialtype"), nullable=False
+    )
+    username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    encrypted_secret: Mapped[str] = mapped_column(Text, nullable=False)
+    encrypted_passphrase: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), onupdate=func.now(), nullable=True
+    )
+
+    def __repr__(self) -> str:
+        return f"<Credential id={self.id} name={self.name!r} type={self.credential_type}>"

--- a/backend/app/schemas/credential.py
+++ b/backend/app/schemas/credential.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.credential import CredentialType
+
+
+class CredentialCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    credential_type: CredentialType
+    username: str | None = Field(default=None, max_length=255)
+    secret: str = Field(min_length=1)
+    passphrase: str | None = None
+
+    @model_validator(mode="after")
+    def username_required_for_password_types(self) -> "CredentialCreate":
+        if self.credential_type in (CredentialType.ssh_password, CredentialType.winrm):
+            if not self.username:
+                raise ValueError("username is required for ssh_password and winrm credentials")
+        return self
+
+
+class CredentialRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    description: str | None
+    credential_type: CredentialType
+    username: str | None
+    created_at: datetime
+    updated_at: datetime | None
+
+
+class CredentialUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    username: str | None = Field(default=None, max_length=255)
+    secret: str | None = Field(default=None, min_length=1)
+    passphrase: str | None = None

--- a/backend/app/schemas/credential.py
+++ b/backend/app/schemas/credential.py
@@ -16,9 +16,9 @@ class CredentialCreate(BaseModel):
 
     @model_validator(mode="after")
     def username_required_for_password_types(self) -> "CredentialCreate":
-        if self.credential_type in (CredentialType.ssh_password, CredentialType.winrm):
-            if not self.username:
-                raise ValueError("username is required for ssh_password and winrm credentials")
+        needs_username = self.credential_type in (CredentialType.ssh_password, CredentialType.winrm)
+        if needs_username and not self.username:
+            raise ValueError("username is required for ssh_password and winrm credentials")
         return self
 
 

--- a/backend/app/services/credentials.py
+++ b/backend/app/services/credentials.py
@@ -1,0 +1,65 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.credential import Credential
+from app.schemas.credential import CredentialCreate, CredentialUpdate
+from app.services.vault import encrypt
+
+
+async def get_credential_by_id(db: AsyncSession, credential_id: uuid.UUID) -> Credential | None:
+    result = await db.execute(select(Credential).where(Credential.id == credential_id))
+    return result.scalar_one_or_none()
+
+
+async def get_credential_by_name(db: AsyncSession, name: str) -> Credential | None:
+    result = await db.execute(select(Credential).where(Credential.name == name))
+    return result.scalar_one_or_none()
+
+
+async def list_credentials(
+    db: AsyncSession, skip: int = 0, limit: int = 100
+) -> list[Credential]:
+    result = await db.execute(
+        select(Credential).order_by(Credential.name).offset(skip).limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def create_credential(db: AsyncSession, data: CredentialCreate) -> Credential:
+    credential = Credential(
+        name=data.name,
+        description=data.description,
+        credential_type=data.credential_type,
+        username=data.username,
+        encrypted_secret=encrypt(data.secret),
+        encrypted_passphrase=encrypt(data.passphrase) if data.passphrase else None,
+    )
+    db.add(credential)
+    await db.commit()
+    await db.refresh(credential)
+    return credential
+
+
+async def update_credential(
+    db: AsyncSession, credential: Credential, data: CredentialUpdate
+) -> Credential:
+    if data.name is not None:
+        credential.name = data.name
+    if data.description is not None:
+        credential.description = data.description
+    if data.username is not None:
+        credential.username = data.username
+    if data.secret is not None:
+        credential.encrypted_secret = encrypt(data.secret)
+    if data.passphrase is not None:
+        credential.encrypted_passphrase = encrypt(data.passphrase)
+    await db.commit()
+    await db.refresh(credential)
+    return credential
+
+
+async def delete_credential(db: AsyncSession, credential: Credential) -> None:
+    await db.delete(credential)
+    await db.commit()

--- a/backend/app/services/credentials.py
+++ b/backend/app/services/credentials.py
@@ -18,9 +18,7 @@ async def get_credential_by_name(db: AsyncSession, name: str) -> Credential | No
     return result.scalar_one_or_none()
 
 
-async def list_credentials(
-    db: AsyncSession, skip: int = 0, limit: int = 100
-) -> list[Credential]:
+async def list_credentials(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[Credential]:
     result = await db.execute(
         select(Credential).order_by(Credential.name).offset(skip).limit(limit)
     )

--- a/backend/app/services/vault.py
+++ b/backend/app/services/vault.py
@@ -1,0 +1,22 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet
+
+from app.core.config import settings
+
+
+def _fernet() -> Fernet:
+    # Derive a 32-byte URL-safe base64 key from secret_key so any string works.
+    # In production, FALCONTROL_SECRET_KEY should be a value from Fernet.generate_key().
+    raw = hashlib.sha256(settings.secret_key.encode()).digest()
+    key = base64.urlsafe_b64encode(raw)
+    return Fernet(key)
+
+
+def encrypt(plaintext: str) -> str:
+    return _fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt(ciphertext: str) -> str:
+    return _fernet().decrypt(ciphertext.encode()).decode()

--- a/backend/tests/test_credentials.py
+++ b/backend/tests/test_credentials.py
@@ -1,0 +1,431 @@
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.user import UserCreate
+from app.services.users import create_user
+
+SSH_KEY_PAYLOAD = {
+    "name": "prod-ssh-key",
+    "credential_type": "ssh_key",
+    "secret": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK...",
+}
+
+SSH_PASS_PAYLOAD = {
+    "name": "prod-ssh-pass",
+    "credential_type": "ssh_password",
+    "username": "deploy",
+    "secret": "s3cur3p@ss",
+}
+
+WINRM_PAYLOAD = {
+    "name": "win-admin",
+    "credential_type": "winrm",
+    "username": "Administrator",
+    "secret": "W!nRM_pass1",
+}
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@test.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def operator_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="operator@test.com", password="operatorpass1", role=UserRole.operator),
+        role=UserRole.operator,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@test.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@test.com", "adminpass1")
+
+
+@pytest.fixture
+async def operator_token(client: AsyncClient, operator_user) -> str:
+    return await _login(client, "operator@test.com", "operatorpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@test.com", "viewerpass1")
+
+
+def _no_secrets_leaked(body: dict) -> bool:
+    forbidden = {"secret", "encrypted_secret", "encrypted_passphrase", "passphrase"}
+    return not forbidden.intersection(body.keys())
+
+
+# --- GET /api/credentials ---
+
+
+async def test_list_credentials_empty(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/credentials", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_credentials_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/credentials")
+    assert resp.status_code == 401
+
+
+async def test_list_credentials_no_secrets(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.get("/api/credentials", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    for item in resp.json():
+        assert _no_secrets_leaked(item)
+
+
+# --- POST /api/credentials ---
+
+
+async def test_create_ssh_key_credential(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "prod-ssh-key"
+    assert body["credential_type"] == "ssh_key"
+    assert body["username"] is None
+    assert "id" in body
+    assert _no_secrets_leaked(body)
+
+
+async def test_create_ssh_key_with_passphrase(client: AsyncClient, admin_token: str) -> None:
+    payload = {**SSH_KEY_PAYLOAD, "passphrase": "key-passphrase"}
+    resp = await client.post(
+        "/api/credentials",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    assert _no_secrets_leaked(resp.json())
+
+
+async def test_create_ssh_password_credential(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_PASS_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["username"] == "deploy"
+    assert _no_secrets_leaked(body)
+
+
+async def test_create_winrm_credential(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.post(
+        "/api/credentials",
+        json=WINRM_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["credential_type"] == "winrm"
+    assert _no_secrets_leaked(resp.json())
+
+
+async def test_create_credential_as_operator(client: AsyncClient, operator_token: str) -> None:
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {operator_token}"},
+    )
+    assert resp.status_code == 201
+
+
+async def test_create_credential_as_viewer_forbidden(
+    client: AsyncClient, viewer_token: str
+) -> None:
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_create_credential_without_auth(client: AsyncClient) -> None:
+    resp = await client.post("/api/credentials", json=SSH_KEY_PAYLOAD)
+    assert resp.status_code == 401
+
+
+async def test_create_credential_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_create_ssh_password_without_username_fails(
+    client: AsyncClient, admin_token: str
+) -> None:
+    payload = {"name": "bad-cred", "credential_type": "ssh_password", "secret": "pass123"}
+    resp = await client.post(
+        "/api/credentials",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_winrm_without_username_fails(client: AsyncClient, admin_token: str) -> None:
+    payload = {"name": "bad-winrm", "credential_type": "winrm", "secret": "pass123"}
+    resp = await client.post(
+        "/api/credentials",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_ssh_key_without_username_ok(client: AsyncClient, admin_token: str) -> None:
+    payload = {
+        "name": "keyonly",
+        "credential_type": "ssh_key",
+        "secret": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...",
+    }
+    resp = await client.post(
+        "/api/credentials",
+        json=payload,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+
+
+# --- GET /api/credentials/{id} ---
+
+
+async def test_get_credential_by_id(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/credentials/{cred_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == cred_id
+    assert _no_secrets_leaked(resp.json())
+
+
+async def test_get_credential_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get(
+        "/api/credentials/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_get_credential_viewer_can_read(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/credentials/{cred_id}", headers={"Authorization": f"Bearer {viewer_token}"}
+    )
+    assert resp.status_code == 200
+    assert _no_secrets_leaked(resp.json())
+
+
+# --- PATCH /api/credentials/{id} ---
+
+
+async def test_patch_credential_name(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/credentials/{cred_id}",
+        json={"name": "renamed-key"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "renamed-key"
+    assert _no_secrets_leaked(resp.json())
+
+
+async def test_patch_credential_secret_re_encrypted(
+    client: AsyncClient, admin_token: str, db_session
+) -> None:
+    import uuid as _uuid
+
+    from app.services.credentials import get_credential_by_id
+    from app.services.vault import decrypt
+
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_PASS_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/credentials/{cred_id}",
+        json={"secret": "newpassword123"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert _no_secrets_leaked(resp.json())
+    cred = await get_credential_by_id(db_session, _uuid.UUID(cred_id))
+    assert cred is not None
+    assert decrypt(cred.encrypted_secret) == "newpassword123"
+
+
+async def test_patch_credential_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.patch(
+        "/api/credentials/00000000-0000-0000-0000-000000000000",
+        json={"name": "ghost"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_patch_credential_duplicate_name(client: AsyncClient, admin_token: str) -> None:
+    await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    c2 = await client.post(
+        "/api/credentials",
+        json=SSH_PASS_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred2_id = c2.json()["id"]
+    resp = await client.patch(
+        f"/api/credentials/{cred2_id}",
+        json={"name": "prod-ssh-key"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 409
+
+
+async def test_patch_credential_viewer_forbidden(
+    client: AsyncClient, admin_token: str, viewer_token: str
+) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.patch(
+        f"/api/credentials/{cred_id}",
+        json={"name": "hacked"},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+# --- DELETE /api/credentials/{id} ---
+
+
+async def test_delete_credential_as_admin(client: AsyncClient, admin_token: str) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/credentials/{cred_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 204
+    get_resp = await client.get(
+        f"/api/credentials/{cred_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert get_resp.status_code == 404
+
+
+async def test_delete_credential_as_operator_forbidden(
+    client: AsyncClient, admin_token: str, operator_token: str
+) -> None:
+    created = await client.post(
+        "/api/credentials",
+        json=SSH_KEY_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/credentials/{cred_id}", headers={"Authorization": f"Bearer {operator_token}"}
+    )
+    assert resp.status_code == 403
+
+
+async def test_delete_credential_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.delete(
+        "/api/credentials/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+# --- Verificación de cifrado en BD ---
+
+
+async def test_secret_stored_encrypted_in_db(
+    client: AsyncClient, admin_token: str, db_session
+) -> None:
+    import uuid as _uuid
+
+    from app.services.credentials import get_credential_by_id
+    from app.services.vault import decrypt
+
+    resp = await client.post(
+        "/api/credentials",
+        json=SSH_PASS_PAYLOAD,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    cred_id = resp.json()["id"]
+    cred = await get_credential_by_id(db_session, _uuid.UUID(cred_id))
+    assert cred is not None
+    assert cred.encrypted_secret != "s3cur3p@ss"
+    assert decrypt(cred.encrypted_secret) == "s3cur3p@ss"


### PR DESCRIPTION
## Resumen

- **`services/vault.py`**: `encrypt()`/`decrypt()` con Fernet. La clave se deriva de `FALCONTROL_SECRET_KEY` via SHA-256+base64url (cualquier string funciona en dev; en producción usar `Fernet.generate_key()`).
- **Modelo `Credential`**: tipos `ssh_key`, `ssh_password`, `winrm`; campos `encrypted_secret` y `encrypted_passphrase` (Text). Los campos cifrados nunca se serializan al cliente.
- **Schemas**: `CredentialRead` omite todos los campos cifrados. `model_validator` en `CredentialCreate` exige `username` para `ssh_password` y `winrm`.
- **Servicio**: cifra al crear, re-cifra solo los campos presentes en PATCH.
- **Router `/api/credentials`**: mismos permisos que hosts/inventarios.
- **Migración** Alembic `0004_create_credentials.py` encadenada a `0003`.

## Tests

- 26 tests de integración — todos verdes
- Suite completa: 85/85 pasados
- Cobertura total: 82%
- Helper `_no_secrets_leaked()` verifica en cada respuesta que `encrypted_secret`, `secret`, `passphrase` y `encrypted_passphrase` nunca aparecen
- Test `test_secret_stored_encrypted_in_db` verifica directamente en BD que el valor almacenado es texto cifrado y que `decrypt()` lo recupera correctamente

## Commits

1. `feat(services)`: vault.py — Fernet encrypt/decrypt
2. `feat(models)`: Credential model
3. `feat(schemas)`: CredentialCreate/Read/Update
4. `feat(services)`: credentials.py CRUD con cifrado transparente
5. `feat(api)`: /api/credentials router
6. `feat(db)`: migración Alembic 0004
7. `test`: integración CRUD /api/credentials

Cierra #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)