### PR TITLE
feat(sprint-3): backend modelo Job + endpoints REST — issue #16

### DIFF
--- a/backend/alembic/versions/0005_create_jobs.py
+++ b/backend/alembic/versions/0005_create_jobs.py
@@ -1,0 +1,54 @@
+"""create jobs table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("inventory_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("playbook_path", sa.String(512), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "running", "success", "failed", name="jobstatus"),
+            nullable=False,
+        ),
+        sa.Column("stdout", sa.Text(), nullable=True),
+        sa.Column("return_code", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["inventory_id"], ["inventories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_jobs_inventory_id", "jobs", ["inventory_id"])
+    op.create_index("ix_jobs_status", "jobs", ["status"])
+    op.create_index("ix_jobs_created_at", "jobs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_created_at", table_name="jobs")
+    op.drop_index("ix_jobs_status", table_name="jobs")
+    op.drop_index("ix_jobs_inventory_id", table_name="jobs")
+    op.drop_table("jobs")
+    op.execute(sa.text("DROP TYPE IF EXISTS jobstatus"))

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@ from app.api.auth import router as auth_router
 from app.api.credentials import router as credentials_router
 from app.api.hosts import router as hosts_router
 from app.api.inventories import router as inventories_router
+from app.api.jobs import router as jobs_router
 from app.api.users import router as users_router
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "credentials_router",
     "hosts_router",
     "inventories_router",
+    "jobs_router",
     "users_router",
 ]

--- a/backend/app/api/jobs.py
+++ b/backend/app/api/jobs.py
@@ -1,0 +1,62 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin, require_operator_or_admin
+from app.core.database import get_db
+from app.models.user import User
+from app.schemas.job import JobCreate, JobRead, JobReadDetail
+from app.services.jobs import create_job, delete_job, get_job_by_id, list_jobs
+from app.tasks.jobs import run_playbook
+
+router = APIRouter(prefix="/jobs", tags=["jobs"])
+
+
+@router.get("", response_model=list[JobRead])
+async def list_jobs_endpoint(
+    skip: int = 0,
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[JobRead]:
+    jobs = await list_jobs(db, skip=skip, limit=limit)
+    return [JobRead.model_validate(j) for j in jobs]
+
+
+@router.post("", response_model=JobRead, status_code=status.HTTP_201_CREATED)
+async def create_job_endpoint(
+    data: JobCreate,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_operator_or_admin),
+) -> JobRead:
+    try:
+        job = await create_job(db, data)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    run_playbook.delay(str(job.id))
+    return JobRead.model_validate(job)
+
+
+@router.get("/{job_id}", response_model=JobReadDetail)
+async def get_job_endpoint(
+    job_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> JobReadDetail:
+    job = await get_job_by_id(db, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return JobReadDetail.model_validate(job)
+
+
+@router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_job_endpoint(
+    job_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> None:
+    job = await get_job_by_id(db, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    await delete_job(db, job)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,14 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import auth_router, credentials_router, hosts_router, inventories_router, users_router
+from app.api import (
+    auth_router,
+    credentials_router,
+    hosts_router,
+    inventories_router,
+    jobs_router,
+    users_router,
+)
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.services.users import ensure_first_admin
@@ -39,6 +46,7 @@ app.include_router(users_router, prefix="/api")
 app.include_router(hosts_router, prefix="/api")
 app.include_router(inventories_router, prefix="/api")
 app.include_router(credentials_router, prefix="/api")
+app.include_router(jobs_router, prefix="/api")
 
 
 @app.get("/api/health", tags=["system"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.credential import Credential, CredentialType
 from app.models.host import ConnectionType, Host, OsType
 from app.models.inventory import Inventory, inventory_hosts
+from app.models.job import Job, JobStatus
 from app.models.user import User, UserRole
 
 __all__ = [
@@ -9,6 +10,8 @@ __all__ = [
     "CredentialType",
     "Host",
     "Inventory",
+    "Job",
+    "JobStatus",
     "OsType",
     "User",
     "UserRole",

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import enum
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID as Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.inventory import Inventory
+
+
+class JobStatus(enum.StrEnum):
+    pending = "pending"
+    running = "running"
+    success = "success"
+    failed = "failed"
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    inventory_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("inventories.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    playbook_path: Mapped[str] = mapped_column(String(512), nullable=False)
+    status: Mapped[JobStatus] = mapped_column(
+        Enum(JobStatus, name="jobstatus"),
+        nullable=False,
+        default=JobStatus.pending,
+        index=True,
+    )
+    stdout: Mapped[str | None] = mapped_column(Text, nullable=True)
+    return_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    inventory: Mapped[Inventory] = relationship("Inventory", lazy="selectin")

--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -26,9 +26,7 @@ class JobStatus(enum.StrEnum):
 class Job(Base):
     __tablename__ = "jobs"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
-    )
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
     inventory_id: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True),
         ForeignKey("inventories.id", ondelete="CASCADE"),
@@ -44,12 +42,8 @@ class Job(Base):
     )
     stdout: Mapped[str | None] = mapped_column(Text, nullable=True)
     return_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    started_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    finished_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
     )

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,7 +1,11 @@
 from app.schemas.auth import LoginRequest, Token, TokenPair
+from app.schemas.job import JobCreate, JobRead, JobReadDetail
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 
 __all__ = [
+    "JobCreate",
+    "JobRead",
+    "JobReadDetail",
     "LoginRequest",
     "Token",
     "TokenPair",

--- a/backend/app/schemas/job.py
+++ b/backend/app/schemas/job.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.job import JobStatus
+
+
+class JobCreate(BaseModel):
+    inventory_id: uuid.UUID
+    playbook_path: str = Field(min_length=1, max_length=512)
+
+
+class JobRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    inventory_id: uuid.UUID
+    playbook_path: str
+    status: JobStatus
+    return_code: int | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    created_at: datetime
+
+
+class JobReadDetail(JobRead):
+    stdout: str | None

--- a/backend/app/services/jobs.py
+++ b/backend/app/services/jobs.py
@@ -21,9 +21,7 @@ async def create_job(db: AsyncSession, data: JobCreate) -> Job:
 
 
 async def list_jobs(db: AsyncSession, skip: int = 0, limit: int = 50) -> list[Job]:
-    result = await db.execute(
-        select(Job).order_by(Job.created_at.desc()).offset(skip).limit(limit)
-    )
+    result = await db.execute(select(Job).order_by(Job.created_at.desc()).offset(skip).limit(limit))
     return list(result.scalars().all())
 
 

--- a/backend/app/services/jobs.py
+++ b/backend/app/services/jobs.py
@@ -1,0 +1,60 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inventory import Inventory
+from app.models.job import Job, JobStatus
+from app.schemas.job import JobCreate
+
+
+async def create_job(db: AsyncSession, data: JobCreate) -> Job:
+    inv = await db.get(Inventory, data.inventory_id)
+    if inv is None:
+        raise ValueError("inventory not found")
+    job = Job(inventory_id=data.inventory_id, playbook_path=data.playbook_path)
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def list_jobs(db: AsyncSession, skip: int = 0, limit: int = 50) -> list[Job]:
+    result = await db.execute(
+        select(Job).order_by(Job.created_at.desc()).offset(skip).limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def get_job_by_id(db: AsyncSession, job_id: uuid.UUID) -> Job | None:
+    return await db.get(Job, job_id)
+
+
+async def delete_job(db: AsyncSession, job: Job) -> None:
+    await db.delete(job)
+    await db.commit()
+
+
+async def mark_running(db: AsyncSession, job: Job) -> Job:
+    job.status = JobStatus.running
+    job.started_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def mark_finished(
+    db: AsyncSession,
+    job: Job,
+    *,
+    return_code: int,
+    stdout: str,
+) -> Job:
+    job.status = JobStatus.success if return_code == 0 else JobStatus.failed
+    job.return_code = return_code
+    job.stdout = stdout
+    job.finished_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(job)
+    return job

--- a/backend/app/tasks/jobs.py
+++ b/backend/app/tasks/jobs.py
@@ -1,1 +1,6 @@
-# Ansible job tasks — populated in Sprint 3
+from app.tasks.celery_app import celery_app
+
+
+@celery_app.task(name="run_playbook")  # type: ignore[untyped-decorator]
+def run_playbook(job_id: str) -> None:
+    """Execute an Ansible playbook for the given job. Implemented in issue #17."""

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -148,9 +148,7 @@ async def test_create_job_without_auth(client: AsyncClient, inventory_id: str) -
     assert resp.status_code == 401
 
 
-async def test_create_job_invalid_inventory(
-    client: AsyncClient, admin_token: str
-) -> None:
+async def test_create_job_invalid_inventory(client: AsyncClient, admin_token: str) -> None:
     with _patch_celery():
         resp = await client.post(
             "/api/jobs",
@@ -166,9 +164,7 @@ async def test_create_job_invalid_inventory(
 # ── GET /api/jobs/{id} ─────────────────────────────────────────────────────
 
 
-async def test_get_job_by_id(
-    client: AsyncClient, admin_token: str, inventory_id: str
-) -> None:
+async def test_get_job_by_id(client: AsyncClient, admin_token: str, inventory_id: str) -> None:
     with _patch_celery():
         created = await client.post(
             "/api/jobs",

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,0 +1,278 @@
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.host import HostCreate
+from app.schemas.inventory import InventoryCreate
+from app.schemas.user import UserCreate
+from app.services.hosts import create_host
+from app.services.inventories import create_inventory
+from app.services.users import create_user
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@test.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def operator_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="operator@test.com", password="operatorpass1", role=UserRole.operator),
+        role=UserRole.operator,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@test.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@test.com", "adminpass1")
+
+
+@pytest.fixture
+async def operator_token(client: AsyncClient, operator_user) -> str:
+    return await _login(client, "operator@test.com", "operatorpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@test.com", "viewerpass1")
+
+
+@pytest.fixture
+async def inventory_id(db_session) -> str:
+    host = await create_host(
+        db_session,
+        HostCreate(name="web-01", address="10.0.0.1", os_type="linux", connection_type="ssh"),
+    )
+    inv = await create_inventory(
+        db_session,
+        InventoryCreate(name="test-inventory", host_ids=[host.id]),
+    )
+    return str(inv.id)
+
+
+JOB_PLAYBOOK = "playbooks-examples/ping.yml"
+
+
+def _patch_celery():
+    return patch("app.api.jobs.run_playbook.delay")
+
+
+# ── GET /api/jobs ──────────────────────────────────────────────────────────
+
+
+async def test_list_jobs_empty(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/jobs", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_jobs_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/jobs")
+    assert resp.status_code == 401
+
+
+# ── POST /api/jobs ─────────────────────────────────────────────────────────
+
+
+async def test_create_job_as_admin(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    with _patch_celery() as mock_delay:
+        resp = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["inventory_id"] == inventory_id
+    assert body["playbook_path"] == JOB_PLAYBOOK
+    assert "stdout" not in body
+    assert "id" in body
+    mock_delay.assert_called_once_with(body["id"])
+
+
+async def test_create_job_as_operator(
+    client: AsyncClient, operator_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        resp = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {operator_token}"},
+        )
+    assert resp.status_code == 201
+
+
+async def test_create_job_viewer_forbidden(
+    client: AsyncClient, viewer_token: str, inventory_id: str
+) -> None:
+    resp = await client.post(
+        "/api/jobs",
+        json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_create_job_without_auth(client: AsyncClient, inventory_id: str) -> None:
+    resp = await client.post(
+        "/api/jobs",
+        json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+    )
+    assert resp.status_code == 401
+
+
+async def test_create_job_invalid_inventory(
+    client: AsyncClient, admin_token: str
+) -> None:
+    with _patch_celery():
+        resp = await client.post(
+            "/api/jobs",
+            json={
+                "inventory_id": "00000000-0000-0000-0000-000000000000",
+                "playbook_path": JOB_PLAYBOOK,
+            },
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    assert resp.status_code == 404
+
+
+# ── GET /api/jobs/{id} ─────────────────────────────────────────────────────
+
+
+async def test_get_job_by_id(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        created = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    job_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == job_id
+    assert "stdout" in body
+
+
+async def test_get_job_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get(
+        "/api/jobs/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_get_job_viewer_can_read(
+    client: AsyncClient, admin_token: str, viewer_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        created = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    job_id = created.json()["id"]
+    resp = await client.get(
+        f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {viewer_token}"}
+    )
+    assert resp.status_code == 200
+
+
+# ── DELETE /api/jobs/{id} ──────────────────────────────────────────────────
+
+
+async def test_delete_job_as_admin(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        created = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    job_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert resp.status_code == 204
+    get_resp = await client.get(
+        f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {admin_token}"}
+    )
+    assert get_resp.status_code == 404
+
+
+async def test_delete_job_operator_forbidden(
+    client: AsyncClient, admin_token: str, operator_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        created = await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    job_id = created.json()["id"]
+    resp = await client.delete(
+        f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {operator_token}"}
+    )
+    assert resp.status_code == 403
+
+
+async def test_delete_job_not_found(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.delete(
+        "/api/jobs/00000000-0000-0000-0000-000000000000",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+# ── Lista refleja jobs creados ─────────────────────────────────────────────
+
+
+async def test_list_jobs_returns_created(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    with _patch_celery():
+        await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": JOB_PLAYBOOK},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        await client.post(
+            "/api/jobs",
+            json={"inventory_id": inventory_id, "playbook_path": "other.yml"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+    resp = await client.get("/api/jobs", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2


### PR DESCRIPTION
## Summary

- Modelo `Job`: id, inventory_id (FK CASCADE), playbook_path, status (pending/running/success/failed), stdout, return_code, started_at, finished_at, created_at
- Migración Alembic `0005_create_jobs` con enum `jobstatus` e índices en inventory_id, status, created_at
- Schemas `JobCreate`, `JobRead` (sin stdout para lista), `JobReadDetail` (con stdout para detalle)
- Servicio `services/jobs.py`: create (valida inventory), list, get_by_id, delete, mark_running, mark_finished
- Router `/api/jobs`: POST (operator+, encola Celery), GET list, GET detail, DELETE (admin)
- Stub `run_playbook` Celery task (se implementa en issue #17)
- 14 tests de integración con `unittest.mock.patch` en `celery.delay` — 99 tests totales en verde

## Test plan

- [ ] CI verde
- [ ] `POST /api/jobs` devuelve `status: pending` y encola la tarea
- [ ] Viewer puede leer, no puede crear; operator puede crear, no puede borrar; admin todo
- [ ] `GET /api/jobs/{id}` incluye campo `stdout`; `GET /api/jobs` no lo incluye
- [ ] Inventory inexistente → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)