### PR TITLE
feat(sprint3): Celery run_playbook + WebSocket logs — issue #17

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api import (
 from app.core.config import settings
 from app.core.database import AsyncSessionLocal
 from app.services.users import ensure_first_admin
+from app.websockets.job_logs import router as job_logs_router
 
 
 @asynccontextmanager
@@ -47,6 +48,7 @@ app.include_router(hosts_router, prefix="/api")
 app.include_router(inventories_router, prefix="/api")
 app.include_router(credentials_router, prefix="/api")
 app.include_router(jobs_router, prefix="/api")
+app.include_router(job_logs_router, prefix="/ws")
 
 
 @app.get("/api/health", tags=["system"])

--- a/backend/app/services/inventory_writer.py
+++ b/backend/app/services/inventory_writer.py
@@ -1,0 +1,18 @@
+from app.models.inventory import Inventory
+
+
+def generate_inventory_ini(inventory: Inventory) -> str:
+    """Build an Ansible INI inventory from an Inventory ORM object."""
+    lines = ["[all]"]
+    for host in inventory.hosts:
+        vars_: list[str] = [f"ansible_host={host.address}"]
+        if host.connection_type.value == "winrm":
+            vars_.append("ansible_connection=winrm")
+            vars_.append(f"ansible_port={host.port or 5985}")
+            vars_.append("ansible_winrm_transport=basic")
+        else:
+            vars_.append("ansible_connection=ssh")
+            if host.port:
+                vars_.append(f"ansible_port={host.port}")
+        lines.append(f"{host.name} " + " ".join(vars_))
+    return "\n".join(lines) + "\n"

--- a/backend/app/tasks/jobs.py
+++ b/backend/app/tasks/jobs.py
@@ -1,6 +1,88 @@
+import asyncio
+import uuid
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import ansible_runner
+import redis as redis_lib
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.services.inventory_writer import generate_inventory_ini
+from app.services.jobs import get_job_by_id, mark_finished, mark_running
 from app.tasks.celery_app import celery_app
+
+
+def _redis_client() -> redis_lib.Redis:
+    return redis_lib.Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def _channel(job_id: str) -> str:
+    return f"job:{job_id}:logs"
+
+
+async def _fetch_job_data(job_id: str) -> tuple[str, str]:
+    """Mark job running; return (playbook_path, inventory_ini)."""
+    async with AsyncSessionLocal() as db:
+        job = await get_job_by_id(db, uuid.UUID(job_id))
+        if job is None:
+            raise RuntimeError(f"Job {job_id} not found")
+        await mark_running(db, job)
+        return job.playbook_path, generate_inventory_ini(job.inventory)
+
+
+async def _save_result(job_id: str, *, return_code: int, stdout: str) -> None:
+    async with AsyncSessionLocal() as db:
+        job = await get_job_by_id(db, uuid.UUID(job_id))
+        if job is not None:
+            await mark_finished(db, job, return_code=return_code, stdout=stdout)
 
 
 @celery_app.task(name="run_playbook")  # type: ignore[untyped-decorator]
 def run_playbook(job_id: str) -> None:
-    """Execute an Ansible playbook for the given job. Implemented in issue #17."""
+    r = _redis_client()
+    channel = _channel(job_id)
+
+    try:
+        playbook_path, inventory_ini = asyncio.run(_fetch_job_data(job_id))
+    except Exception as exc:  # noqa: BLE001
+        r.publish(channel, f"ERROR: {exc}")
+        r.publish(channel, "__END__")
+        return
+
+    stdout_lines: list[str] = []
+
+    def event_handler(event: dict[str, Any]) -> None:
+        line: str = event.get("stdout", "")
+        if line:
+            stdout_lines.append(line)
+            r.publish(channel, line)
+
+    with TemporaryDirectory() as tmpdir:
+        inv_path = Path(tmpdir) / "inventory.ini"
+        inv_path.write_text(inventory_ini)
+
+        project_dir = Path(tmpdir) / "project"
+        project_dir.mkdir()
+
+        pb = Path(playbook_path)
+        if pb.is_absolute():
+            pb_link = project_dir / pb.name
+            pb_link.symlink_to(pb)
+            playbook_name = pb.name
+        else:
+            playbook_name = playbook_path
+
+        result: Any = ansible_runner.run(
+            private_data_dir=tmpdir,
+            playbook=playbook_name,
+            inventory=str(inv_path),
+            event_handler=event_handler,
+            quiet=True,
+        )
+        return_code: int = result.rc
+        stdout = "\n".join(stdout_lines)
+
+    asyncio.run(_save_result(job_id, return_code=return_code, stdout=stdout))
+    r.publish(channel, "__END__")

--- a/backend/app/websockets/job_logs.py
+++ b/backend/app/websockets/job_logs.py
@@ -1,0 +1,83 @@
+import asyncio
+import uuid
+
+import redis.asyncio as aioredis
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.core.config import settings
+from app.core.database import AsyncSessionLocal
+from app.models.job import JobStatus
+from app.services.auth import decode_token
+from app.services.jobs import get_job_by_id
+
+router = APIRouter()
+
+_SENTINEL = "__END__"
+_KEEPALIVE_INTERVAL = 25.0  # seconds between pings when idle
+
+
+@router.websocket("/jobs/{job_id}/logs")
+async def job_logs(
+    websocket: WebSocket,
+    job_id: uuid.UUID,
+    token: str | None = None,
+) -> None:
+    # ── Auth ──────────────────────────────────────────────────────────────
+    if not token:
+        await websocket.close(code=1008, reason="Missing token")
+        return
+    try:
+        payload = decode_token(token)
+        if payload.get("type") != "access":
+            raise ValueError("not an access token")
+    except Exception:
+        await websocket.close(code=1008, reason="Invalid token")
+        return
+
+    await websocket.accept()
+
+    # ── Check if job already finished ─────────────────────────────────────
+    async with AsyncSessionLocal() as db:
+        job = await get_job_by_id(db, job_id)
+        if job is None:
+            await websocket.send_text("__ERROR__: Job not found")
+            await websocket.close()
+            return
+        if job.status in (JobStatus.success, JobStatus.failed):
+            if job.stdout:
+                for line in job.stdout.splitlines():
+                    await websocket.send_text(line)
+            await websocket.send_text(_SENTINEL)
+            await websocket.close()
+            return
+
+    # ── Stream live from Redis pub/sub ────────────────────────────────────
+    r: aioredis.Redis = aioredis.Redis.from_url(settings.redis_url, decode_responses=True)
+    pubsub = r.pubsub()
+    channel = f"job:{job_id}:logs"
+    await pubsub.subscribe(channel)
+    try:
+        while True:
+            try:
+                message = await asyncio.wait_for(
+                    pubsub.get_message(ignore_subscribe_messages=True),
+                    timeout=_KEEPALIVE_INTERVAL,
+                )
+            except TimeoutError:
+                await websocket.send_text("__PING__")
+                continue
+
+            if message is None:
+                await asyncio.sleep(0.05)
+                continue
+
+            data: str = message["data"]
+            if data == _SENTINEL:
+                await websocket.send_text(_SENTINEL)
+                break
+            await websocket.send_text(data)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await pubsub.unsubscribe(channel)
+        await r.aclose()

--- a/backend/tests/test_run_playbook.py
+++ b/backend/tests/test_run_playbook.py
@@ -1,0 +1,149 @@
+"""Unit tests for the run_playbook Celery task.
+
+ansible_runner.run, Redis, and async DB helpers are fully mocked so these
+tests run without network, Redis, or Ansible installed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.tasks.jobs import _channel, run_playbook
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_runner_result(rc: int = 0) -> MagicMock:
+    result = MagicMock()
+    result.rc = rc
+    return result
+
+
+def _make_host(name: str = "web-01", address: str = "10.0.0.1") -> MagicMock:
+    host = MagicMock()
+    host.name = name
+    host.address = address
+    host.port = None
+    host.connection_type.value = "ssh"
+    return host
+
+
+# ── _channel ──────────────────────────────────────────────────────────────
+
+
+def test_channel_format() -> None:
+    assert _channel("abc-123") == "job:abc-123:logs"
+
+
+# ── run_playbook — success path ────────────────────────────────────────────
+
+
+@patch("app.tasks.jobs._save_result", new_callable=AsyncMock)
+@patch("app.tasks.jobs._fetch_job_data", new_callable=AsyncMock)
+@patch("app.tasks.jobs.ansible_runner.run")
+@patch("app.tasks.jobs._redis_client")
+def test_run_playbook_success(
+    mock_redis_cls: MagicMock,
+    mock_ar_run: MagicMock,
+    mock_fetch: AsyncMock,
+    mock_save: AsyncMock,
+) -> None:
+    job_id = "00000000-0000-0000-0000-000000000001"
+
+    mock_fetch.return_value = ("ping.yml", "[all]\nweb-01 ansible_host=10.0.0.1\n")
+    mock_ar_run.return_value = _make_runner_result(rc=0)
+
+    mock_r = MagicMock()
+    mock_redis_cls.return_value = mock_r
+
+    run_playbook(job_id)
+
+    mock_fetch.assert_called_once_with(job_id)
+    mock_ar_run.assert_called_once()
+    mock_save.assert_called_once()
+    # __END__ sentinel published
+    mock_r.publish.assert_called_with(_channel(job_id), "__END__")
+
+
+# ── run_playbook — failure path (non-zero rc) ──────────────────────────────
+
+
+@patch("app.tasks.jobs._save_result", new_callable=AsyncMock)
+@patch("app.tasks.jobs._fetch_job_data", new_callable=AsyncMock)
+@patch("app.tasks.jobs.ansible_runner.run")
+@patch("app.tasks.jobs._redis_client")
+def test_run_playbook_failed_rc(
+    mock_redis_cls: MagicMock,
+    mock_ar_run: MagicMock,
+    mock_fetch: AsyncMock,
+    mock_save: AsyncMock,
+) -> None:
+    job_id = "00000000-0000-0000-0000-000000000002"
+
+    mock_fetch.return_value = ("ping.yml", "[all]\nweb-01 ansible_host=10.0.0.1\n")
+    mock_ar_run.return_value = _make_runner_result(rc=2)
+    mock_redis_cls.return_value = MagicMock()
+
+    run_playbook(job_id)
+
+    # _save_result called with return_code=2
+    _, kwargs = mock_save.call_args
+    assert kwargs["return_code"] == 2
+
+
+# ── run_playbook — job not found ───────────────────────────────────────────
+
+
+@patch("app.tasks.jobs._fetch_job_data", new_callable=AsyncMock)
+@patch("app.tasks.jobs._redis_client")
+def test_run_playbook_job_not_found(
+    mock_redis_cls: MagicMock,
+    mock_fetch: AsyncMock,
+) -> None:
+    job_id = "00000000-0000-0000-0000-000000000003"
+    mock_fetch.side_effect = RuntimeError("Job not found")
+    mock_r = MagicMock()
+    mock_redis_cls.return_value = mock_r
+
+    run_playbook(job_id)
+
+    # Error + sentinel published, ansible_runner never called
+    calls = [str(c) for c in mock_r.publish.call_args_list]
+    assert any("ERROR" in c for c in calls)
+    assert any("__END__" in c for c in calls)
+
+
+# ── run_playbook — event_handler publishes stdout lines ───────────────────
+
+
+@patch("app.tasks.jobs._save_result", new_callable=AsyncMock)
+@patch("app.tasks.jobs._fetch_job_data", new_callable=AsyncMock)
+@patch("app.tasks.jobs.ansible_runner.run")
+@patch("app.tasks.jobs._redis_client")
+def test_run_playbook_publishes_stdout(
+    mock_redis_cls: MagicMock,
+    mock_ar_run: MagicMock,
+    mock_fetch: AsyncMock,
+    mock_save: AsyncMock,
+) -> None:
+    job_id = "00000000-0000-0000-0000-000000000004"
+    mock_fetch.return_value = ("ping.yml", "[all]\n")
+    mock_r = MagicMock()
+    mock_redis_cls.return_value = mock_r
+
+    # Simulate event_handler being called with stdout lines
+    def fake_run(**kwargs: object) -> MagicMock:
+        handler = kwargs.get("event_handler")
+        if callable(handler):
+            handler({"stdout": "PLAY [all] *****"})
+            handler({"stdout": "ok: [web-01]"})
+            handler({"stdout": ""})  # empty line — should be ignored
+        return _make_runner_result(rc=0)
+
+    mock_ar_run.side_effect = fake_run
+
+    run_playbook(job_id)
+
+    published = [str(c) for c in mock_r.publish.call_args_list]
+    assert any("PLAY [all]" in c for c in published)
+    assert any("ok: [web-01]" in c for c in published)
+    # empty line not published
+    assert not any("''" in c and "publish" in c for c in published)


### PR DESCRIPTION
## Summary
- `app/services/inventory_writer.py`: genera `inventory.ini` desde ORM para ansible-runner
- `app/tasks/jobs.py`: tarea Celery `run_playbook` — ejecuta playbook con ansible-runner, publica stdout línea a línea en Redis pub/sub (`job:<id>:logs`), guarda resultado en BD
- `app/websockets/job_logs.py`: WebSocket `/ws/jobs/{job_id}/logs` — autentica con JWT vía query param, retransmite pub/sub en vivo; si el job ya terminó sirve el stdout almacenado
- `app/main.py`: registra el router WebSocket bajo el prefijo `/ws`
- `tests/test_run_playbook.py`: 5 tests unitarios (sin red, Redis ni Ansible real)

## Test plan
- [x] `pytest tests/test_run_playbook.py` — 5/5 passed
- [x] `ruff check . && ruff format --check .` — sin errores
- [x] `mypy app/` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)