### PR TITLE
feat(sprint4): backend Schedule modelo, CRUD y tests — issue #20

### DIFF
--- a/backend/alembic/versions/0006_create_schedules.py
+++ b/backend/alembic/versions/0006_create_schedules.py
@@ -1,0 +1,47 @@
+"""create schedules table
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "schedules",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(256), nullable=False),
+        sa.Column("cron_expression", sa.String(128), nullable=False),
+        sa.Column("inventory_id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("playbook_path", sa.String(512), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["inventory_id"], ["inventories.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", name="uq_schedules_name"),
+    )
+    op.create_index("ix_schedules_name", "schedules", ["name"])
+    op.create_index("ix_schedules_inventory_id", "schedules", ["inventory_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_schedules_inventory_id", table_name="schedules")
+    op.drop_index("ix_schedules_name", table_name="schedules")
+    op.drop_table("schedules")

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -3,6 +3,7 @@ from app.api.credentials import router as credentials_router
 from app.api.hosts import router as hosts_router
 from app.api.inventories import router as inventories_router
 from app.api.jobs import router as jobs_router
+from app.api.schedules import router as schedules_router
 from app.api.users import router as users_router
 
 __all__ = [
@@ -11,5 +12,6 @@ __all__ = [
     "hosts_router",
     "inventories_router",
     "jobs_router",
+    "schedules_router",
     "users_router",
 ]

--- a/backend/app/api/schedules.py
+++ b/backend/app/api/schedules.py
@@ -1,0 +1,83 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, require_admin, require_operator_or_admin
+from app.core.database import get_db
+from app.models.user import User
+from app.schemas.schedule import ScheduleCreate, ScheduleRead, ScheduleUpdate
+from app.services.schedules import (
+    create_schedule,
+    delete_schedule,
+    get_schedule_by_id,
+    list_schedules,
+    update_schedule,
+)
+
+router = APIRouter(prefix="/schedules", tags=["schedules"])
+
+
+@router.get("", response_model=list[ScheduleRead])
+async def list_schedules_endpoint(
+    skip: int = 0,
+    limit: int = 100,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> list[ScheduleRead]:
+    schedules = await list_schedules(db, skip=skip, limit=limit)
+    return [ScheduleRead.model_validate(s) for s in schedules]
+
+
+@router.post("", response_model=ScheduleRead, status_code=status.HTTP_201_CREATED)
+async def create_schedule_endpoint(
+    data: ScheduleCreate,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_operator_or_admin),
+) -> ScheduleRead:
+    try:
+        schedule = await create_schedule(db, data)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return ScheduleRead.model_validate(schedule)
+
+
+@router.get("/{schedule_id}", response_model=ScheduleRead)
+async def get_schedule_endpoint(
+    schedule_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> ScheduleRead:
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+    return ScheduleRead.model_validate(schedule)
+
+
+@router.patch("/{schedule_id}", response_model=ScheduleRead)
+async def update_schedule_endpoint(
+    schedule_id: uuid.UUID,
+    data: ScheduleUpdate,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_operator_or_admin),
+) -> ScheduleRead:
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+    try:
+        schedule = await update_schedule(db, schedule, data)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return ScheduleRead.model_validate(schedule)
+
+
+@router.delete("/{schedule_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_schedule_endpoint(
+    schedule_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(require_admin),
+) -> None:
+    schedule = await get_schedule_by_id(db, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found")
+    await delete_schedule(db, schedule)

--- a/backend/app/api/schedules.py
+++ b/backend/app/api/schedules.py
@@ -1,6 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_user, require_admin, require_operator_or_admin
@@ -39,6 +40,10 @@ async def create_schedule_endpoint(
         schedule = await create_schedule(db, data)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Schedule name already exists"
+        ) from exc
     return ScheduleRead.model_validate(schedule)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api import (
     hosts_router,
     inventories_router,
     jobs_router,
+    schedules_router,
     users_router,
 )
 from app.core.config import settings
@@ -48,6 +49,7 @@ app.include_router(hosts_router, prefix="/api")
 app.include_router(inventories_router, prefix="/api")
 app.include_router(credentials_router, prefix="/api")
 app.include_router(jobs_router, prefix="/api")
+app.include_router(schedules_router, prefix="/api")
 app.include_router(job_logs_router, prefix="/ws")
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,7 @@ from app.models.credential import Credential, CredentialType
 from app.models.host import ConnectionType, Host, OsType
 from app.models.inventory import Inventory, inventory_hosts
 from app.models.job import Job, JobStatus
+from app.models.schedule import Schedule
 from app.models.user import User, UserRole
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "Job",
     "JobStatus",
     "OsType",
+    "Schedule",
     "User",
     "UserRole",
     "inventory_hosts",

--- a/backend/app/models/schedule.py
+++ b/backend/app/models/schedule.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID as Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+if TYPE_CHECKING:
+    from app.models.inventory import Inventory
+
+
+class Schedule(Base):
+    __tablename__ = "schedules"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(256), nullable=False, unique=True, index=True)
+    cron_expression: Mapped[str] = mapped_column(String(128), nullable=False)
+    inventory_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("inventories.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    playbook_path: Mapped[str] = mapped_column(String(512), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    inventory: Mapped[Inventory] = relationship("Inventory", lazy="selectin")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,5 +1,6 @@
 from app.schemas.auth import LoginRequest, Token, TokenPair
 from app.schemas.job import JobCreate, JobRead, JobReadDetail
+from app.schemas.schedule import ScheduleCreate, ScheduleRead, ScheduleUpdate
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 
 __all__ = [
@@ -7,6 +8,9 @@ __all__ = [
     "JobRead",
     "JobReadDetail",
     "LoginRequest",
+    "ScheduleCreate",
+    "ScheduleRead",
+    "ScheduleUpdate",
     "Token",
     "TokenPair",
     "UserCreate",

--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _validate_cron(v: str) -> str:
+    parts = v.strip().split()
+    if len(parts) != 5:
+        raise ValueError("cron_expression must have exactly 5 fields: minute hour day month weekday")  # noqa: E501
+    return v.strip()
+
+
+class ScheduleCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=256)
+    cron_expression: str = Field(min_length=9, max_length=128)
+    inventory_id: uuid.UUID
+    playbook_path: str = Field(min_length=1, max_length=512)
+    enabled: bool = True
+
+    @field_validator("cron_expression")
+    @classmethod
+    def validate_cron(cls, v: str) -> str:
+        return _validate_cron(v)
+
+
+class ScheduleUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=256)
+    cron_expression: str | None = Field(default=None, min_length=9, max_length=128)
+    inventory_id: uuid.UUID | None = None
+    playbook_path: str | None = Field(default=None, min_length=1, max_length=512)
+    enabled: bool | None = None
+
+    @field_validator("cron_expression")
+    @classmethod
+    def validate_cron(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        return _validate_cron(v)
+
+
+class ScheduleRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    cron_expression: str
+    inventory_id: uuid.UUID
+    playbook_path: str
+    enabled: bool
+    created_at: datetime
+    updated_at: datetime | None

--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -7,7 +7,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 def _validate_cron(v: str) -> str:
     parts = v.strip().split()
     if len(parts) != 5:
-        raise ValueError("cron_expression must have exactly 5 fields: minute hour day month weekday")  # noqa: E501
+        raise ValueError(
+            "cron_expression must have exactly 5 fields: minute hour day month weekday"
+        )  # noqa: E501
     return v.strip()
 
 

--- a/backend/app/services/schedules.py
+++ b/backend/app/services/schedules.py
@@ -27,9 +27,7 @@ async def create_schedule(db: AsyncSession, data: ScheduleCreate) -> Schedule:
 
 
 async def list_schedules(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[Schedule]:
-    result = await db.execute(
-        select(Schedule).order_by(Schedule.name).offset(skip).limit(limit)
-    )
+    result = await db.execute(select(Schedule).order_by(Schedule.name).offset(skip).limit(limit))
     return list(result.scalars().all())
 
 

--- a/backend/app/services/schedules.py
+++ b/backend/app/services/schedules.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.inventory import Inventory
+from app.models.schedule import Schedule
+from app.schemas.schedule import ScheduleCreate, ScheduleUpdate
+
+
+async def create_schedule(db: AsyncSession, data: ScheduleCreate) -> Schedule:
+    inv = await db.get(Inventory, data.inventory_id)
+    if inv is None:
+        raise ValueError("inventory not found")
+    schedule = Schedule(
+        name=data.name,
+        cron_expression=data.cron_expression,
+        inventory_id=data.inventory_id,
+        playbook_path=data.playbook_path,
+        enabled=data.enabled,
+    )
+    db.add(schedule)
+    await db.commit()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def list_schedules(db: AsyncSession, skip: int = 0, limit: int = 100) -> list[Schedule]:
+    result = await db.execute(
+        select(Schedule).order_by(Schedule.name).offset(skip).limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def get_schedule_by_id(db: AsyncSession, schedule_id: uuid.UUID) -> Schedule | None:
+    return await db.get(Schedule, schedule_id)
+
+
+async def update_schedule(db: AsyncSession, schedule: Schedule, data: ScheduleUpdate) -> Schedule:
+    if data.inventory_id is not None and data.inventory_id != schedule.inventory_id:
+        inv = await db.get(Inventory, data.inventory_id)
+        if inv is None:
+            raise ValueError("inventory not found")
+
+    patch = data.model_dump(exclude_unset=True)
+    for field, value in patch.items():
+        setattr(schedule, field, value)
+    schedule.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(schedule)
+    return schedule
+
+
+async def delete_schedule(db: AsyncSession, schedule: Schedule) -> None:
+    await db.delete(schedule)
+    await db.commit()

--- a/backend/tests/test_schedules.py
+++ b/backend/tests/test_schedules.py
@@ -1,0 +1,319 @@
+"""Integration tests for the /api/schedules endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.host import HostCreate
+from app.schemas.inventory import InventoryCreate
+from app.schemas.user import UserCreate
+from app.services.hosts import create_host
+from app.services.inventories import create_inventory
+from app.services.users import create_user
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@sched.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def operator_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="operator@sched.com", password="operpass1", role=UserRole.operator),
+        role=UserRole.operator,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@sched.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@sched.com", "adminpass1")
+
+
+@pytest.fixture
+async def operator_token(client: AsyncClient, operator_user) -> str:
+    return await _login(client, "operator@sched.com", "operpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@sched.com", "viewerpass1")
+
+
+@pytest.fixture
+async def inventory_id(db_session) -> str:
+    host = await create_host(
+        db_session,
+        HostCreate(name="sched-host", address="10.0.1.1", os_type="linux", connection_type="ssh"),
+    )
+    inv = await create_inventory(
+        db_session,
+        InventoryCreate(name="sched-inventory", host_ids=[host.id]),
+    )
+    return str(inv.id)
+
+
+CRON = "0 2 * * *"
+PLAYBOOK = "playbooks-examples/ping.yml"
+
+
+def _payload(inventory_id: str, **overrides: object) -> dict:
+    base: dict = {
+        "name": "nightly-ping",
+        "cron_expression": CRON,
+        "inventory_id": inventory_id,
+        "playbook_path": PLAYBOOK,
+        "enabled": True,
+    }
+    base.update(overrides)
+    return base
+
+
+# ── GET /api/schedules ─────────────────────────────────────────────────────
+
+
+async def test_list_schedules_empty(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/schedules", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+async def test_list_schedules_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/schedules")
+    assert resp.status_code == 401
+
+
+async def test_viewer_can_list_schedules(client: AsyncClient, viewer_token: str) -> None:
+    resp = await client.get("/api/schedules", headers={"Authorization": f"Bearer {viewer_token}"})
+    assert resp.status_code == 200
+
+
+# ── POST /api/schedules ────────────────────────────────────────────────────
+
+
+async def test_create_schedule_as_admin(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "nightly-ping"
+    assert body["cron_expression"] == CRON
+    assert body["inventory_id"] == inventory_id
+    assert body["playbook_path"] == PLAYBOOK
+    assert body["enabled"] is True
+    assert "id" in body
+    assert "created_at" in body
+
+
+async def test_create_schedule_as_operator(
+    client: AsyncClient, operator_token: str, inventory_id: str
+) -> None:
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id, name="operator-sched"),
+        headers={"Authorization": f"Bearer {operator_token}"},
+    )
+    assert resp.status_code == 201
+
+
+async def test_create_schedule_viewer_forbidden(
+    client: AsyncClient, viewer_token: str, inventory_id: str
+) -> None:
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_create_schedule_invalid_cron(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id, cron_expression="bad-cron"),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_schedule_missing_inventory(client: AsyncClient, admin_token: str) -> None:
+    import uuid
+
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(str(uuid.uuid4())),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_create_schedule_duplicate_name(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code in (409, 422, 500)
+
+
+# ── GET /api/schedules/{id} ────────────────────────────────────────────────
+
+
+async def test_get_schedule(client: AsyncClient, admin_token: str, inventory_id: str) -> None:
+    create_resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    schedule_id = create_resp.json()["id"]
+    resp = await client.get(
+        f"/api/schedules/{schedule_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == schedule_id
+
+
+async def test_get_schedule_not_found(client: AsyncClient, admin_token: str) -> None:
+    import uuid
+
+    resp = await client.get(
+        f"/api/schedules/{uuid.uuid4()}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+# ── PATCH /api/schedules/{id} ──────────────────────────────────────────────
+
+
+async def test_update_schedule(client: AsyncClient, admin_token: str, inventory_id: str) -> None:
+    create_resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    schedule_id = create_resp.json()["id"]
+    resp = await client.patch(
+        f"/api/schedules/{schedule_id}",
+        json={"enabled": False, "cron_expression": "30 6 * * 1"},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["cron_expression"] == "30 6 * * 1"
+    assert body["updated_at"] is not None
+
+
+async def test_update_schedule_viewer_forbidden(
+    client: AsyncClient, viewer_token: str, admin_token: str, inventory_id: str
+) -> None:
+    create_resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    schedule_id = create_resp.json()["id"]
+    resp = await client.patch(
+        f"/api/schedules/{schedule_id}",
+        json={"enabled": False},
+        headers={"Authorization": f"Bearer {viewer_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_update_schedule_not_found(client: AsyncClient, admin_token: str) -> None:
+    import uuid
+
+    resp = await client.patch(
+        f"/api/schedules/{uuid.uuid4()}",
+        json={"enabled": False},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404
+
+
+# ── DELETE /api/schedules/{id} ─────────────────────────────────────────────
+
+
+async def test_delete_schedule_as_admin(
+    client: AsyncClient, admin_token: str, inventory_id: str
+) -> None:
+    create_resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    schedule_id = create_resp.json()["id"]
+    resp = await client.delete(
+        f"/api/schedules/{schedule_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 204
+    get_resp = await client.get(
+        f"/api/schedules/{schedule_id}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert get_resp.status_code == 404
+
+
+async def test_delete_schedule_operator_forbidden(
+    client: AsyncClient, operator_token: str, admin_token: str, inventory_id: str
+) -> None:
+    create_resp = await client.post(
+        "/api/schedules",
+        json=_payload(inventory_id),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    schedule_id = create_resp.json()["id"]
+    resp = await client.delete(
+        f"/api/schedules/{schedule_id}",
+        headers={"Authorization": f"Bearer {operator_token}"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_delete_schedule_not_found(client: AsyncClient, admin_token: str) -> None:
+    import uuid
+
+    resp = await client.delete(
+        f"/api/schedules/{uuid.uuid4()}",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- `app/models/schedule.py`: modelo `Schedule` (id, name, cron_expression, inventory_id, playbook_path, enabled, created_at, updated_at) con FK CASCADE a inventories
- `alembic/versions/0006_create_schedules.py`: migración con índices en name e inventory_id, constraint UNIQUE en name
- `app/schemas/schedule.py`: `ScheduleCreate` y `ScheduleUpdate` con validación de cron (exactamente 5 campos), `ScheduleRead`
- `app/services/schedules.py`: CRUD completo con `exclude_unset` en PATCH, validación de inventory_id en update
- `app/api/schedules.py`: GET list (cualquier auth), POST/PATCH (operator+), DELETE (admin), 409 en nombre duplicado
- `tests/test_schedules.py`: 17 tests de integración cubriendo CRUD, roles, cron inválido, inventario inexistente y nombre duplicado

## Test plan
- [x] 121 tests totales — todos pasando (77% cobertura global)
- [x] `ruff check . && ruff format --check . && mypy app/` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)