### PR TITLE
feat(sprint4): backend endpoint GET /api/dashboard — issue #22

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,5 +1,6 @@
 from app.api.auth import router as auth_router
 from app.api.credentials import router as credentials_router
+from app.api.dashboard import router as dashboard_router
 from app.api.hosts import router as hosts_router
 from app.api.inventories import router as inventories_router
 from app.api.jobs import router as jobs_router
@@ -9,6 +10,7 @@ from app.api.users import router as users_router
 __all__ = [
     "auth_router",
     "credentials_router",
+    "dashboard_router",
     "hosts_router",
     "inventories_router",
     "jobs_router",

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user
+from app.core.database import get_db
+from app.models.user import User
+from app.schemas.dashboard import DashboardStats
+from app.services.dashboard import get_dashboard_stats
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+@router.get("", response_model=DashboardStats)
+async def dashboard_endpoint(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+) -> DashboardStats:
+    return await get_dashboard_stats(db)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api import (
     auth_router,
     credentials_router,
+    dashboard_router,
     hosts_router,
     inventories_router,
     jobs_router,
@@ -50,6 +51,7 @@ app.include_router(inventories_router, prefix="/api")
 app.include_router(credentials_router, prefix="/api")
 app.include_router(jobs_router, prefix="/api")
 app.include_router(schedules_router, prefix="/api")
+app.include_router(dashboard_router, prefix="/api")
 app.include_router(job_logs_router, prefix="/ws")
 
 

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+from app.schemas.job import JobRead
+
+
+class DashboardStats(BaseModel):
+    total_hosts: int
+    total_inventories: int
+    total_schedules: int
+    total_jobs: int
+    running_jobs: int
+    failed_last_24h: int
+    recent_jobs: list[JobRead]

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -1,0 +1,48 @@
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.host import Host
+from app.models.inventory import Inventory
+from app.models.job import Job, JobStatus
+from app.models.schedule import Schedule
+from app.schemas.dashboard import DashboardStats
+from app.schemas.job import JobRead
+
+
+async def get_dashboard_stats(db: AsyncSession) -> DashboardStats:
+    total_hosts = await db.scalar(select(func.count()).select_from(Host)) or 0
+    total_inventories = await db.scalar(select(func.count()).select_from(Inventory)) or 0
+    total_schedules = await db.scalar(select(func.count()).select_from(Schedule)) or 0
+    total_jobs = await db.scalar(select(func.count()).select_from(Job)) or 0
+
+    running_jobs = (
+        await db.scalar(
+            select(func.count()).select_from(Job).where(Job.status == JobStatus.running)
+        )
+        or 0
+    )
+
+    since = datetime.now(UTC) - timedelta(hours=24)
+    failed_last_24h = (
+        await db.scalar(
+            select(func.count())
+            .select_from(Job)
+            .where(Job.status == JobStatus.failed, Job.created_at >= since)
+        )
+        or 0
+    )
+
+    recent_result = await db.execute(select(Job).order_by(Job.created_at.desc()).limit(10))
+    recent_jobs = [JobRead.model_validate(j) for j in recent_result.scalars().all()]
+
+    return DashboardStats(
+        total_hosts=total_hosts,
+        total_inventories=total_inventories,
+        total_schedules=total_schedules,
+        total_jobs=total_jobs,
+        running_jobs=running_jobs,
+        failed_last_24h=failed_last_24h,
+        recent_jobs=recent_jobs,
+    )

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,103 @@
+"""Integration tests for GET /api/dashboard."""
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.models.user import UserRole
+from app.schemas.host import HostCreate
+from app.schemas.inventory import InventoryCreate
+from app.schemas.job import JobCreate
+from app.schemas.user import UserCreate
+from app.services.hosts import create_host
+from app.services.inventories import create_inventory
+from app.services.jobs import create_job
+from app.services.users import create_user
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def admin_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="admin@dash.com", password="adminpass1", role=UserRole.admin),
+        role=UserRole.admin,
+    )
+
+
+@pytest.fixture
+async def viewer_user(db_session):
+    return await create_user(
+        db_session,
+        UserCreate(email="viewer@dash.com", password="viewerpass1", role=UserRole.viewer),
+        role=UserRole.viewer,
+    )
+
+
+async def _login(client: AsyncClient, email: str, password: str) -> str:
+    resp = await client.post("/api/auth/login", json={"email": email, "password": password})
+    return str(resp.json()["access_token"])
+
+
+@pytest.fixture
+async def admin_token(client: AsyncClient, admin_user) -> str:
+    return await _login(client, "admin@dash.com", "adminpass1")
+
+
+@pytest.fixture
+async def viewer_token(client: AsyncClient, viewer_user) -> str:
+    return await _login(client, "viewer@dash.com", "viewerpass1")
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+async def test_dashboard_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get("/api/dashboard")
+    assert resp.status_code == 401
+
+
+async def test_dashboard_empty_db(client: AsyncClient, admin_token: str) -> None:
+    resp = await client.get("/api/dashboard", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_hosts"] == 0
+    assert body["total_inventories"] == 0
+    assert body["total_schedules"] == 0
+    assert body["total_jobs"] == 0
+    assert body["running_jobs"] == 0
+    assert body["failed_last_24h"] == 0
+    assert body["recent_jobs"] == []
+
+
+async def test_dashboard_viewer_can_access(client: AsyncClient, viewer_token: str) -> None:
+    resp = await client.get("/api/dashboard", headers={"Authorization": f"Bearer {viewer_token}"})
+    assert resp.status_code == 200
+
+
+async def test_dashboard_counts_resources(
+    client: AsyncClient, admin_token: str, db_session
+) -> None:
+    host = await create_host(
+        db_session,
+        HostCreate(name="dash-host", address="10.0.2.1", os_type="linux", connection_type="ssh"),
+    )
+    inv = await create_inventory(
+        db_session,
+        InventoryCreate(name="dash-inventory", host_ids=[host.id]),
+    )
+    with patch("app.tasks.jobs.run_playbook.delay"):
+        await create_job(db_session, JobCreate(inventory_id=inv.id, playbook_path="ping.yml"))
+        await create_job(db_session, JobCreate(inventory_id=inv.id, playbook_path="ping.yml"))
+
+    resp = await client.get("/api/dashboard", headers={"Authorization": f"Bearer {admin_token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_hosts"] == 1
+    assert body["total_inventories"] == 1
+    assert body["total_jobs"] == 2
+    assert len(body["recent_jobs"]) == 2
+    # recent_jobs must be ordered newest first
+    assert body["recent_jobs"][0]["created_at"] >= body["recent_jobs"][1]["created_at"]


### PR DESCRIPTION
## Summary
- `app/schemas/dashboard.py`: `DashboardStats` con total_hosts, total_inventories, total_schedules, total_jobs, running_jobs, failed_last_24h y recent_jobs (últimos 10)
- `app/services/dashboard.py`: 7 queries async SQLAlchemy; `failed_last_24h` filtra por `created_at >= now-24h`; `recent_jobs` ordenados por `created_at desc`
- `app/api/dashboard.py`: `GET /api/dashboard` accesible por cualquier rol autenticado
- `tests/test_dashboard.py`: 4 tests (sin auth, BD vacía, viewer, con datos reales)

## Test plan
- [x] 134 tests totales — todos pasando (78% cobertura global)
- [x] `ruff check . && ruff format --check . && mypy app/` — sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)