### PR TITLE
feat(frontend): SchedulesView y DashboardView — Sprint 4 issue #23

### DIFF
--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -1,0 +1,7 @@
+import axios from 'axios'
+import type { DashboardStats } from '@/types'
+
+export async function getDashboardStats(): Promise<DashboardStats> {
+  const { data } = await axios.get<DashboardStats>('/api/dashboard')
+  return data
+}

--- a/frontend/src/api/schedules.ts
+++ b/frontend/src/api/schedules.ts
@@ -1,0 +1,28 @@
+import axios from 'axios'
+import type { Schedule, ScheduleCreate, ScheduleUpdate } from '@/types'
+
+const base = '/api/schedules'
+
+export async function listSchedules(): Promise<Schedule[]> {
+  const { data } = await axios.get<Schedule[]>(base)
+  return data
+}
+
+export async function getSchedule(id: string): Promise<Schedule> {
+  const { data } = await axios.get<Schedule>(`${base}/${id}`)
+  return data
+}
+
+export async function createSchedule(payload: ScheduleCreate): Promise<Schedule> {
+  const { data } = await axios.post<Schedule>(base, payload)
+  return data
+}
+
+export async function updateSchedule(id: string, payload: ScheduleUpdate): Promise<Schedule> {
+  const { data } = await axios.patch<Schedule>(`${base}/${id}`, payload)
+  return data
+}
+
+export async function deleteSchedule(id: string): Promise<void> {
+  await axios.delete(`${base}/${id}`)
+}

--- a/frontend/src/components/AppLayout.vue
+++ b/frontend/src/components/AppLayout.vue
@@ -12,11 +12,12 @@ async function handleLogout() {
 }
 
 const navLinks = [
-  { name: 'Dashboard', to: '/', icon: 'home' },
+  { name: 'Dashboard', to: '/dashboard', icon: 'home' },
   { name: 'Hosts', to: '/hosts', icon: 'server' },
   { name: 'Inventarios', to: '/inventories', icon: 'collection' },
   { name: 'Credenciales', to: '/credentials', icon: 'key' },
   { name: 'Jobs', to: '/jobs', icon: 'play' },
+  { name: 'Schedules', to: '/schedules', icon: 'clock' },
 ]
 
 function isActive(path: string): boolean {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -46,6 +46,16 @@ const router = createRouter({
           name: 'job-detail',
           component: () => import('@/views/JobDetailView.vue'),
         },
+        {
+          path: 'schedules',
+          name: 'schedules',
+          component: () => import('@/views/SchedulesView.vue'),
+        },
+        {
+          path: 'dashboard',
+          name: 'dashboard',
+          component: () => import('@/views/DashboardView.vue'),
+        },
       ],
     },
   ],

--- a/frontend/src/stores/dashboard.ts
+++ b/frontend/src/stores/dashboard.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { getDashboardStats } from '@/api/dashboard'
+import type { DashboardStats } from '@/types'
+
+export const useDashboardStore = defineStore('dashboard', () => {
+  const stats = ref<DashboardStats | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchStats() {
+    loading.value = true
+    error.value = null
+    try {
+      stats.value = await getDashboardStats()
+    } catch {
+      error.value = 'Error al cargar el dashboard'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { stats, loading, error, fetchStats }
+})

--- a/frontend/src/stores/schedules.ts
+++ b/frontend/src/stores/schedules.ts
@@ -6,7 +6,7 @@ import {
   updateSchedule,
   deleteSchedule,
 } from '@/api/schedules'
-import type { Schedule, ScheduleCreate, ScheduleUpdate } from '@/types'
+import type { Schedule, ScheduleCreate } from '@/types'
 
 export const useSchedulesStore = defineStore('schedules', () => {
   const schedules = ref<Schedule[]>([])

--- a/frontend/src/stores/schedules.ts
+++ b/frontend/src/stores/schedules.ts
@@ -1,0 +1,61 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  listSchedules,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+} from '@/api/schedules'
+import type { Schedule, ScheduleCreate, ScheduleUpdate } from '@/types'
+
+export const useSchedulesStore = defineStore('schedules', () => {
+  const schedules = ref<Schedule[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchAll() {
+    loading.value = true
+    error.value = null
+    try {
+      schedules.value = await listSchedules()
+    } catch {
+      error.value = 'Error al cargar los schedules'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function addSchedule(payload: ScheduleCreate): Promise<Schedule | null> {
+    error.value = null
+    try {
+      const s = await createSchedule(payload)
+      schedules.value.push(s)
+      return s
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const resp = (err as { response?: { status?: number } }).response
+        if (resp?.status === 409) {
+          error.value = 'Ya existe un schedule con ese nombre'
+        } else {
+          error.value = 'Error al crear el schedule'
+        }
+      } else {
+        error.value = 'Error al crear el schedule'
+      }
+      return null
+    }
+  }
+
+  async function toggleEnabled(schedule: Schedule): Promise<void> {
+    const updated = await updateSchedule(schedule.id, { enabled: !schedule.enabled })
+    const idx = schedules.value.findIndex((s) => s.id === schedule.id)
+    if (idx !== -1) schedules.value[idx] = updated
+  }
+
+  async function removeSchedule(id: string): Promise<void> {
+    await deleteSchedule(id)
+    schedules.value = schedules.value.filter((s) => s.id !== id)
+  }
+
+  return { schedules, loading, error, fetchAll, addSchedule, toggleEnabled, removeSchedule }
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -109,6 +109,47 @@ export interface JobCreate {
   playbook_path: string
 }
 
+// ── Schedules ──────────────────────────────────────────────────────────────
+
+export interface Schedule {
+  id: string
+  name: string
+  cron_expression: string
+  inventory_id: string
+  playbook_path: string
+  enabled: boolean
+  created_at: string
+  updated_at: string | null
+}
+
+export interface ScheduleCreate {
+  name: string
+  cron_expression: string
+  inventory_id: string
+  playbook_path: string
+  enabled?: boolean
+}
+
+export interface ScheduleUpdate {
+  name?: string
+  cron_expression?: string
+  inventory_id?: string
+  playbook_path?: string
+  enabled?: boolean
+}
+
+// ── Dashboard ──────────────────────────────────────────────────────────────
+
+export interface DashboardStats {
+  total_hosts: number
+  total_inventories: number
+  total_schedules: number
+  total_jobs: number
+  running_jobs: number
+  failed_last_24h: number
+  recent_jobs: Job[]
+}
+
 // ── Credentials ────────────────────────────────────────────────────────────
 
 export type CredentialType = 'ssh_key' | 'ssh_password' | 'winrm'

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useDashboardStore } from '@/stores/dashboard'
+import JobStatusBadge from '@/components/JobStatusBadge.vue'
+
+const router = useRouter()
+const dashboardStore = useDashboardStore()
+
+onMounted(() => dashboardStore.fetchStats())
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('es-ES', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+interface StatCard {
+  label: string
+  key: keyof Pick<
+    NonNullable<typeof dashboardStore.stats>,
+    'total_hosts' | 'total_inventories' | 'total_schedules' | 'total_jobs' | 'running_jobs' | 'failed_last_24h'
+  >
+  accent: string
+}
+
+const statCards: StatCard[] = [
+  { label: 'Hosts', key: 'total_hosts', accent: 'text-brand-400' },
+  { label: 'Inventarios', key: 'total_inventories', accent: 'text-blue-400' },
+  { label: 'Schedules', key: 'total_schedules', accent: 'text-purple-400' },
+  { label: 'Jobs totales', key: 'total_jobs', accent: 'text-gray-300' },
+  { label: 'Jobs activos', key: 'running_jobs', accent: 'text-green-400' },
+  { label: 'Fallos (24h)', key: 'failed_last_24h', accent: 'text-red-400' },
+]
+</script>
+
+<template>
+  <div>
+    <h2 class="text-xl font-semibold text-white mb-6">Dashboard</h2>
+
+    <!-- Error -->
+    <p v-if="dashboardStore.error" class="text-red-400 text-sm mb-4">{{ dashboardStore.error }}</p>
+
+    <!-- Loading -->
+    <div v-if="dashboardStore.loading" class="text-gray-500 text-sm">Cargando…</div>
+
+    <template v-else-if="dashboardStore.stats">
+      <!-- Stat cards -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+        <div
+          v-for="card in statCards"
+          :key="card.key"
+          class="bg-gray-900 border border-gray-800 rounded-xl px-5 py-4 flex flex-col gap-1"
+        >
+          <span class="text-xs text-gray-500">{{ card.label }}</span>
+          <span class="text-3xl font-bold" :class="card.accent">
+            {{ dashboardStore.stats[card.key] }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Recent jobs -->
+      <div>
+        <h3 class="text-sm font-medium text-gray-400 mb-3">Jobs recientes</h3>
+
+        <div
+          v-if="!dashboardStore.stats.recent_jobs.length"
+          class="text-center py-10 text-gray-600 text-sm"
+        >
+          No hay jobs todavía.
+        </div>
+
+        <div v-else class="overflow-x-auto rounded-xl border border-gray-800">
+          <table class="w-full text-sm">
+            <thead class="bg-gray-900 text-gray-400 text-left">
+              <tr>
+                <th class="px-4 py-3 font-medium">Estado</th>
+                <th class="px-4 py-3 font-medium">Playbook</th>
+                <th class="px-4 py-3 font-medium">RC</th>
+                <th class="px-4 py-3 font-medium">Creado</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800">
+              <tr
+                v-for="job in dashboardStore.stats.recent_jobs"
+                :key="job.id"
+                class="bg-gray-950 hover:bg-gray-900 transition-colors cursor-pointer"
+                @click="router.push({ name: 'job-detail', params: { id: job.id } })"
+              >
+                <td class="px-4 py-3">
+                  <JobStatusBadge :status="job.status" />
+                </td>
+                <td class="px-4 py-3 text-gray-300 font-mono text-xs truncate max-w-xs">
+                  {{ job.playbook_path }}
+                </td>
+                <td class="px-4 py-3 text-gray-400">{{ job.return_code ?? '—' }}</td>
+                <td class="px-4 py-3 text-gray-500">{{ formatDate(job.created_at) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/frontend/src/views/SchedulesView.vue
+++ b/frontend/src/views/SchedulesView.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useSchedulesStore } from '@/stores/schedules'
+import { useInventoriesStore } from '@/stores/inventories'
+import { useAuthStore } from '@/stores/auth'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+
+const schedulesStore = useSchedulesStore()
+const inventoriesStore = useInventoriesStore()
+const auth = useAuthStore()
+
+const showForm = ref(false)
+const saving = ref(false)
+const form = ref({
+  name: '',
+  cron_expression: '',
+  inventory_id: '',
+  playbook_path: '',
+  enabled: true,
+})
+
+const scheduleToDelete = ref<string | null>(null)
+
+onMounted(async () => {
+  await Promise.all([schedulesStore.fetchAll(), inventoriesStore.fetchAll()])
+})
+
+async function handleCreate() {
+  if (
+    !form.value.name.trim() ||
+    !form.value.cron_expression.trim() ||
+    !form.value.inventory_id ||
+    !form.value.playbook_path.trim()
+  )
+    return
+  saving.value = true
+  const s = await schedulesStore.addSchedule({
+    name: form.value.name.trim(),
+    cron_expression: form.value.cron_expression.trim(),
+    inventory_id: form.value.inventory_id,
+    playbook_path: form.value.playbook_path.trim(),
+    enabled: form.value.enabled,
+  })
+  saving.value = false
+  if (s) {
+    showForm.value = false
+    form.value = { name: '', cron_expression: '', inventory_id: '', playbook_path: '', enabled: true }
+  }
+}
+
+async function handleToggle(schedule: (typeof schedulesStore.schedules)[number]) {
+  await schedulesStore.toggleEnabled(schedule)
+}
+
+async function confirmDelete() {
+  if (!scheduleToDelete.value) return
+  await schedulesStore.removeSchedule(scheduleToDelete.value)
+  scheduleToDelete.value = null
+}
+
+function inventoryName(id: string): string {
+  return inventoriesStore.inventories.find((i) => i.id === id)?.name ?? id.slice(0, 8) + '…'
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString('es-ES', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+const canManage = auth.user?.role === 'admin' || auth.user?.role === 'operator'
+const isAdmin = auth.user?.role === 'admin'
+</script>
+
+<template>
+  <div>
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+      <h2 class="text-xl font-semibold text-white">Schedules</h2>
+      <button
+        v-if="canManage"
+        class="px-4 py-2 text-sm bg-brand-600 hover:bg-brand-500 text-white rounded-lg transition-colors"
+        @click="showForm = true"
+      >
+        Nuevo schedule
+      </button>
+    </div>
+
+    <!-- Create form -->
+    <div v-if="showForm" class="mb-6 bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <h3 class="text-sm font-medium text-white mb-4">Nuevo schedule</h3>
+      <form class="grid grid-cols-1 gap-4 sm:grid-cols-2" @submit.prevent="handleCreate">
+        <div>
+          <label class="block text-xs text-gray-400 mb-1">Nombre</label>
+          <input
+            v-model="form.name"
+            type="text"
+            placeholder="backup-diario"
+            required
+            class="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          />
+        </div>
+        <div>
+          <label class="block text-xs text-gray-400 mb-1">Expresión cron <span class="text-gray-600">(min hora día mes weekday)</span></label>
+          <input
+            v-model="form.cron_expression"
+            type="text"
+            placeholder="0 2 * * *"
+            required
+            class="w-full bg-gray-800 border border-gray-700 text-white font-mono rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          />
+        </div>
+        <div>
+          <label class="block text-xs text-gray-400 mb-1">Inventario</label>
+          <select
+            v-model="form.inventory_id"
+            required
+            class="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          >
+            <option value="" disabled>Selecciona un inventario…</option>
+            <option v-for="inv in inventoriesStore.inventories" :key="inv.id" :value="inv.id">
+              {{ inv.name }}
+            </option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-xs text-gray-400 mb-1">Ruta del playbook</label>
+          <input
+            v-model="form.playbook_path"
+            type="text"
+            placeholder="/opt/playbooks/backup.yml"
+            required
+            class="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          />
+        </div>
+        <div class="flex items-center gap-2 sm:col-span-2">
+          <input
+            id="enabled"
+            v-model="form.enabled"
+            type="checkbox"
+            class="h-4 w-4 rounded border-gray-700 bg-gray-800 accent-brand-500"
+          />
+          <label for="enabled" class="text-sm text-gray-400">Habilitado</label>
+        </div>
+        <div class="sm:col-span-2 flex justify-end gap-3">
+          <button
+            type="button"
+            class="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+            @click="showForm = false"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            :disabled="saving"
+            class="px-4 py-2 text-sm bg-brand-600 hover:bg-brand-500 disabled:opacity-50 text-white rounded-lg transition-colors"
+          >
+            {{ saving ? 'Guardando…' : 'Crear' }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Error -->
+    <p v-if="schedulesStore.error" class="text-red-400 text-sm mb-4">{{ schedulesStore.error }}</p>
+
+    <!-- Loading -->
+    <div v-if="schedulesStore.loading" class="text-gray-500 text-sm">Cargando…</div>
+
+    <!-- Empty -->
+    <div
+      v-else-if="!schedulesStore.schedules.length"
+      class="text-center py-16 text-gray-600 text-sm"
+    >
+      No hay schedules todavía.
+    </div>
+
+    <!-- Table -->
+    <div v-else class="overflow-x-auto rounded-xl border border-gray-800">
+      <table class="w-full text-sm">
+        <thead class="bg-gray-900 text-gray-400 text-left">
+          <tr>
+            <th class="px-4 py-3 font-medium">Nombre</th>
+            <th class="px-4 py-3 font-medium">Cron</th>
+            <th class="px-4 py-3 font-medium">Inventario</th>
+            <th class="px-4 py-3 font-medium">Playbook</th>
+            <th class="px-4 py-3 font-medium">Estado</th>
+            <th class="px-4 py-3 font-medium">Creado</th>
+            <th class="px-4 py-3 font-medium w-24"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          <tr
+            v-for="s in schedulesStore.schedules"
+            :key="s.id"
+            class="bg-gray-950 hover:bg-gray-900 transition-colors"
+          >
+            <td class="px-4 py-3 text-white font-medium">{{ s.name }}</td>
+            <td class="px-4 py-3 text-gray-300 font-mono text-xs">{{ s.cron_expression }}</td>
+            <td class="px-4 py-3 text-gray-400">{{ inventoryName(s.inventory_id) }}</td>
+            <td class="px-4 py-3 text-gray-300 font-mono text-xs truncate max-w-xs">
+              {{ s.playbook_path }}
+            </td>
+            <td class="px-4 py-3">
+              <button
+                v-if="canManage"
+                class="text-xs px-2 py-0.5 rounded-full border transition-colors"
+                :class="
+                  s.enabled
+                    ? 'border-green-700 text-green-400 hover:border-green-500'
+                    : 'border-gray-700 text-gray-500 hover:border-gray-500'
+                "
+                @click="handleToggle(s)"
+              >
+                {{ s.enabled ? 'Activo' : 'Inactivo' }}
+              </button>
+              <span
+                v-else
+                class="text-xs px-2 py-0.5 rounded-full border"
+                :class="
+                  s.enabled
+                    ? 'border-green-700 text-green-400'
+                    : 'border-gray-700 text-gray-500'
+                "
+              >
+                {{ s.enabled ? 'Activo' : 'Inactivo' }}
+              </span>
+            </td>
+            <td class="px-4 py-3 text-gray-500">{{ formatDate(s.created_at) }}</td>
+            <td class="px-4 py-3 text-right">
+              <button
+                v-if="isAdmin"
+                class="text-gray-600 hover:text-red-400 transition-colors text-xs"
+                @click="scheduleToDelete = s.id"
+              >
+                Eliminar
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Confirm delete -->
+    <ConfirmModal
+      :open="scheduleToDelete !== null"
+      title="Eliminar schedule"
+      message="¿Eliminar este schedule? Se desregistrará de Celery Beat y no se ejecutará más."
+      confirm-label="Eliminar"
+      @confirm="confirmDelete"
+      @cancel="scheduleToDelete = null"
+    />
+  </div>
+</template>


### PR DESCRIPTION
## Resumen

- Tipos TypeScript para `Schedule` y `DashboardStats` en `types/index.ts`
- Clientes API tipados para `/api/schedules` y `/api/dashboard`
- Pinia stores `useSchedulesStore` y `useDashboardStore`
- `SchedulesView`: tabla con toggle enabled/disabled, formulario de creación, eliminación con confirmación
- `DashboardView`: 6 tarjetas de métricas + tabla de últimos 10 jobs con enlace al detalle
- Rutas `/schedules` y `/dashboard` añadidas al router
- Enlace **Schedules** añadido al sidebar; **Dashboard** redirige ahora a `/dashboard`

## Plan de tests

- [ ] Iniciar sesión como admin y verificar que el sidebar muestra Dashboard y Schedules
- [ ] Abrir `/dashboard` — deben aparecer las 6 tarjetas con valores numéricos
- [ ] Crear un schedule con cron `0 2 * * *` y verificar que aparece en la tabla
- [ ] Hacer toggle del estado activo/inactivo y verificar que cambia en BD
- [ ] Eliminar el schedule y verificar que desaparece de la tabla
- [ ] Verificar que viewer no ve botones de creación ni eliminación

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)