### PR TITLE
docs: README v0.4.0, docs/api.md y docs/user-guide.md — issue #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/Jfalcon19/falcontrol/actions/workflows/ci.yml/badge.svg)](https://github.com/Jfalcon19/falcontrol/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](https://github.com/Jfalcon19/falcontrol/releases)
 
 ## ¿Qué es Falcontrol?
 
@@ -13,17 +14,35 @@ Falcontrol te permite gestionar tus sistemas Linux y Windows con Ansible desde u
 docker compose up -d
 ```
 
+## Funcionalidades
+
+- **Gestión de hosts**: CRUD de hosts Linux/Windows con SSH y WinRM
+- **Inventarios**: agrupación de hosts en inventarios reutilizables
+- **Credenciales cifradas**: SSH key, password y WinRM almacenadas con Fernet
+- **Ejecución de jobs**: lanzar playbooks Ansible contra inventarios con logs en tiempo real
+- **Scheduler**: programar ejecuciones periódicas con expresiones cron
+- **Dashboard**: métricas globales y últimos jobs de un vistazo
+- **Roles de usuario**: admin, operator y viewer
+
 ## Stack
 
 | Capa | Tecnología |
 |------|------------|
 | Backend | FastAPI + SQLAlchemy async + PostgreSQL 16 |
 | Tareas async | Celery + Redis |
+| Scheduler | Celery Beat + RedBeat |
 | Frontend | Vue 3 + TypeScript + Tailwind CSS |
 | Ejecución Ansible | ansible-runner |
 | Infraestructura | Docker Compose + Nginx |
 
 ## Inicio rápido
+
+### Requisitos previos
+
+- Docker Engine 24+ y Docker Compose v2
+- Ansible instalado en el host (o incluido en la imagen del backend)
+
+### Instalación
 
 ```bash
 # 1. Clonar el repositorio
@@ -32,7 +51,21 @@ cd falcontrol
 
 # 2. Copiar y editar variables de entorno
 cp .env.example .env
-# Edita .env con tus valores (mínimo: FALCONTROL_SECRET_KEY, POSTGRES_PASSWORD)
+$EDITOR .env
+```
+
+**Variables obligatorias en `.env`:**
+
+| Variable | Descripción |
+|----------|-------------|
+| `FALCONTROL_SECRET_KEY` | Clave Fernet base64 — genera con el comando de abajo |
+| `POSTGRES_PASSWORD` | Password de PostgreSQL |
+| `FIRST_ADMIN_EMAIL` | Email del primer administrador |
+| `FIRST_ADMIN_PASSWORD` | Password del primer admin (mín. 8 caracteres) |
+
+```bash
+# Generar FALCONTROL_SECRET_KEY
+python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 
 # 3. Levantar el stack completo
 docker compose up -d
@@ -41,24 +74,41 @@ docker compose up -d
 open http://localhost
 ```
 
+El primer arranque crea automáticamente el usuario administrador definido en `.env`.
+
 ## Desarrollo local
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 ```
 
-El modo dev activa hot-reload en backend y frontend, y expone los puertos directamente al host.
+El modo dev activa hot-reload en backend y frontend y expone los puertos directamente al host:
+
+| Servicio | URL |
+|----------|-----|
+| Frontend | `http://localhost:5173` |
+| Backend / Swagger | `http://localhost:8000/api/docs` |
+
+### Ejecutar tests
+
+```bash
+# Backend
+cd backend && uv run pytest
+
+# Frontend
+cd frontend && npm run test
+```
 
 ## Documentación
 
+- [API Reference](docs/api.md) — todos los endpoints con ejemplos curl
+- [Guía de usuario](docs/user-guide.md) — guía para administradores
 - [Arquitectura](docs/architecture.md)
-- [API](docs/api.md)
-- [Guía de usuario](docs/user-guide.md)
 - [Para colaboradores / Claude Code](CLAUDE.md)
 
 ## Estado del proyecto
 
-> Sprint 0 — Setup inicial en curso.
+**v0.4.0** — Sprint 4 completado. Funcionalidades implementadas: auth, hosts, inventarios, credenciales, jobs con logs WebSocket, scheduler con Celery Beat y dashboard de métricas.
 
 ## Licencia
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,525 @@
+# Falcontrol API Reference
+
+Base URL: `http://localhost/api`  
+Swagger UI interactivo: `http://localhost/api/docs`
+
+## Autenticación
+
+Todos los endpoints (excepto `/auth/login`) requieren cabecera:
+
+```
+Authorization: Bearer <access_token>
+```
+
+El access token expira en **15 minutos**. Usa `/auth/refresh` para renovarlo.
+
+---
+
+## Auth
+
+### POST /auth/login
+
+Obtiene un par de tokens.
+
+```bash
+curl -X POST http://localhost/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "admin@empresa.com", "password": "tu_password"}'
+```
+
+**Respuesta 200:**
+```json
+{
+  "access_token": "eyJ...",
+  "refresh_token": "eyJ...",
+  "token_type": "bearer"
+}
+```
+
+### POST /auth/refresh
+
+Renueva el access token usando el refresh token (válido 7 días).
+
+```bash
+curl -X POST http://localhost/api/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token": "eyJ..."}'
+```
+
+### GET /auth/me
+
+Devuelve el usuario autenticado.
+
+```bash
+curl http://localhost/api/auth/me \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "email": "admin@empresa.com",
+  "role": "admin",
+  "is_active": true,
+  "created_at": "2026-01-01T00:00:00Z"
+}
+```
+
+---
+
+## Usuarios
+
+> Requiere rol **admin**.
+
+### POST /users
+
+Crea un nuevo usuario.
+
+```bash
+curl -X POST http://localhost/api/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "operador@empresa.com", "password": "password123", "role": "operator"}'
+```
+
+Roles disponibles: `admin`, `operator`, `viewer`.
+
+---
+
+## Hosts
+
+### GET /hosts
+
+Lista todos los hosts. Soporta paginación y filtro por estado.
+
+```bash
+# Todos los hosts activos (por defecto)
+curl http://localhost/api/hosts \
+  -H "Authorization: Bearer $TOKEN"
+
+# Con paginación
+curl "http://localhost/api/hosts?skip=0&limit=50" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Incluir hosts inactivos
+curl "http://localhost/api/hosts?active_only=false" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+[
+  {
+    "id": "...",
+    "name": "servidor-web-01",
+    "address": "192.168.1.10",
+    "description": "Servidor web principal",
+    "os_type": "linux",
+    "connection_type": "ssh",
+    "port": 22,
+    "tags": ["web", "produccion"],
+    "is_active": true,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": null
+  }
+]
+```
+
+### POST /hosts
+
+> Requiere rol **operator** o **admin**.
+
+```bash
+curl -X POST http://localhost/api/hosts \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "servidor-db-01",
+    "address": "192.168.1.20",
+    "os_type": "linux",
+    "connection_type": "ssh",
+    "port": 22,
+    "tags": ["db", "produccion"],
+    "description": "Base de datos principal"
+  }'
+```
+
+`os_type`: `linux` | `windows`  
+`connection_type`: `ssh` | `winrm`
+
+### GET /hosts/{host_id}
+
+```bash
+curl http://localhost/api/hosts/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### PATCH /hosts/{host_id}
+
+> Requiere rol **operator** o **admin**. Solo se actualizan los campos enviados.
+
+```bash
+curl -X PATCH http://localhost/api/hosts/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Nueva descripción", "tags": ["web"]}'
+```
+
+### DELETE /hosts/{host_id}
+
+> Requiere rol **admin**.
+
+```bash
+curl -X DELETE http://localhost/api/hosts/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Responde `204 No Content`.
+
+---
+
+## Inventarios
+
+Los inventarios agrupan hosts para ejecutar playbooks sobre ellos.
+
+### GET /inventories
+
+```bash
+curl http://localhost/api/inventories \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+[
+  {
+    "id": "...",
+    "name": "servidores-web",
+    "description": "Todos los servidores web",
+    "hosts": [ { "id": "...", "name": "servidor-web-01", ... } ],
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": null
+  }
+]
+```
+
+### POST /inventories
+
+> Requiere rol **operator** o **admin**.
+
+```bash
+curl -X POST http://localhost/api/inventories \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "servidores-web",
+    "description": "Todos los servidores web",
+    "host_ids": ["uuid-host-1", "uuid-host-2"]
+  }'
+```
+
+### GET /inventories/{inventory_id}
+
+```bash
+curl http://localhost/api/inventories/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### PATCH /inventories/{inventory_id}
+
+> Requiere rol **operator** o **admin**.
+
+```bash
+curl -X PATCH http://localhost/api/inventories/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"host_ids": ["uuid-host-1", "uuid-host-2", "uuid-host-3"]}'
+```
+
+### DELETE /inventories/{inventory_id}
+
+> Requiere rol **admin**.
+
+```bash
+curl -X DELETE http://localhost/api/inventories/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Credenciales
+
+Los secretos nunca se devuelven en las respuestas; se cifran con Fernet en base de datos.
+
+### GET /credentials
+
+```bash
+curl http://localhost/api/credentials \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+[
+  {
+    "id": "...",
+    "name": "clave-ssh-produccion",
+    "description": "Clave SSH para servidores de producción",
+    "credential_type": "ssh_key",
+    "username": "deploy",
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": null
+  }
+]
+```
+
+### POST /credentials
+
+> Requiere rol **operator** o **admin**.
+
+```bash
+# SSH key
+curl -X POST http://localhost/api/credentials \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "clave-ssh-produccion",
+    "credential_type": "ssh_key",
+    "username": "deploy",
+    "secret": "-----BEGIN OPENSSH PRIVATE KEY-----\n...",
+    "passphrase": "opcional"
+  }'
+
+# Password SSH
+curl -X POST http://localhost/api/credentials \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "password-ssh",
+    "credential_type": "ssh_password",
+    "username": "admin",
+    "secret": "tu_password"
+  }'
+
+# WinRM
+curl -X POST http://localhost/api/credentials \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "winrm-windows",
+    "credential_type": "winrm",
+    "username": "Administrator",
+    "secret": "tu_password_windows"
+  }'
+```
+
+`credential_type`: `ssh_key` | `ssh_password` | `winrm`
+
+### GET /credentials/{credential_id}
+
+```bash
+curl http://localhost/api/credentials/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### PATCH /credentials/{credential_id}
+
+> Requiere rol **operator** o **admin**.
+
+### DELETE /credentials/{credential_id}
+
+> Requiere rol **admin**.
+
+---
+
+## Jobs
+
+### GET /jobs
+
+Lista los jobs más recientes (orden: más nuevo primero).
+
+```bash
+# Últimos 20 jobs
+curl "http://localhost/api/jobs?skip=0&limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+[
+  {
+    "id": "...",
+    "inventory_id": "...",
+    "playbook_path": "/opt/playbooks/deploy.yml",
+    "status": "success",
+    "return_code": 0,
+    "started_at": "2026-01-01T10:00:00Z",
+    "finished_at": "2026-01-01T10:02:30Z",
+    "created_at": "2026-01-01T10:00:00Z"
+  }
+]
+```
+
+`status`: `pending` | `running` | `success` | `failed`
+
+### POST /jobs
+
+> Requiere rol **operator** o **admin**. Lanza el playbook de forma asíncrona via Celery.
+
+```bash
+curl -X POST http://localhost/api/jobs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inventory_id": "550e8400-e29b-41d4-a716-446655440000",
+    "playbook_path": "/opt/playbooks/deploy.yml"
+  }'
+```
+
+**Respuesta 201:**
+```json
+{
+  "id": "...",
+  "status": "pending",
+  ...
+}
+```
+
+### GET /jobs/{job_id}
+
+Devuelve el detalle del job incluyendo el stdout completo.
+
+```bash
+curl http://localhost/api/jobs/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### DELETE /jobs/{job_id}
+
+> Requiere rol **admin**.
+
+### WebSocket: logs en tiempo real
+
+```
+ws://localhost/ws/jobs/{job_id}/logs?token=<access_token>
+```
+
+El servidor emite las líneas de stdout a medida que se producen. Mensajes de control:
+- `__PING__` — keepalive cada 25 s (ignorar)
+- `__END__` — job finalizado, cerrar la conexión
+
+Si el job ya terminó al conectar, se reenvía el stdout almacenado seguido de `__END__`.
+
+---
+
+## Schedules
+
+### GET /schedules
+
+```bash
+curl "http://localhost/api/schedules?skip=0&limit=20" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+[
+  {
+    "id": "...",
+    "name": "backup-diario",
+    "cron_expression": "0 2 * * *",
+    "inventory_id": "...",
+    "playbook_path": "/opt/playbooks/backup.yml",
+    "enabled": true,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": null
+  }
+]
+```
+
+### POST /schedules
+
+> Requiere rol **operator** o **admin**.
+
+```bash
+curl -X POST http://localhost/api/schedules \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "backup-diario",
+    "cron_expression": "0 2 * * *",
+    "inventory_id": "550e8400-e29b-41d4-a716-446655440000",
+    "playbook_path": "/opt/playbooks/backup.yml",
+    "enabled": true
+  }'
+```
+
+`cron_expression`: 5 campos — `minuto hora día mes día_semana`.  
+Ejemplos: `0 2 * * *` (cada día a las 02:00), `*/15 * * * *` (cada 15 min), `0 8 * * 1` (lunes a las 08:00).
+
+### GET /schedules/{schedule_id}
+
+```bash
+curl http://localhost/api/schedules/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### PATCH /schedules/{schedule_id}
+
+> Requiere rol **operator** o **admin**. Actualiza solo los campos enviados.
+
+```bash
+# Deshabilitar un schedule
+curl -X PATCH http://localhost/api/schedules/550e8400-e29b-41d4-a716-446655440000 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": false}'
+```
+
+### DELETE /schedules/{schedule_id}
+
+> Requiere rol **admin**. El schedule se elimina de Celery Beat automáticamente.
+
+---
+
+## Dashboard
+
+### GET /dashboard
+
+Devuelve un resumen de métricas del sistema.
+
+```bash
+curl http://localhost/api/dashboard \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Respuesta 200:**
+```json
+{
+  "total_hosts": 12,
+  "total_inventories": 4,
+  "total_schedules": 3,
+  "total_jobs": 247,
+  "running_jobs": 1,
+  "failed_last_24h": 2,
+  "recent_jobs": [ ... ]
+}
+```
+
+`recent_jobs` contiene los últimos 10 jobs ordenados por fecha de creación (más reciente primero).
+
+---
+
+## Códigos de error comunes
+
+| Código | Significado |
+|--------|-------------|
+| `400` | Validación fallida (body malformado) |
+| `401` | Token ausente, inválido o expirado |
+| `403` | Rol insuficiente para esta operación |
+| `404` | Recurso no encontrado |
+| `409` | Conflicto — nombre duplicado |
+| `422` | Error de validación Pydantic (campos incorrectos) |
+| `429` | Too Many Requests — rate limit superado |
+| `500` | Error interno del servidor |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,206 @@
+# Guía de usuario — Falcontrol
+
+Esta guía explica el flujo de trabajo habitual para un administrador: desde el primer acceso hasta lanzar un playbook programado.
+
+## Índice
+
+1. [Primer acceso](#1-primer-acceso)
+2. [Gestión de hosts](#2-gestión-de-hosts)
+3. [Inventarios](#3-inventarios)
+4. [Credenciales](#4-credenciales)
+5. [Lanzar un job](#5-lanzar-un-job)
+6. [Ver logs en tiempo real](#6-ver-logs-en-tiempo-real)
+7. [Programar ejecuciones](#7-programar-ejecuciones)
+8. [Dashboard](#8-dashboard)
+9. [Gestión de usuarios](#9-gestión-de-usuarios)
+10. [Roles y permisos](#10-roles-y-permisos)
+
+---
+
+## 1. Primer acceso
+
+Tras levantar el stack con `docker compose up -d`, abre `http://localhost` en tu navegador.
+
+Inicia sesión con las credenciales definidas en `.env` (`FIRST_ADMIN_EMAIL` / `FIRST_ADMIN_PASSWORD`). Estas credenciales son las del primer usuario administrador, creado automáticamente al arrancar.
+
+> **Cambia la contraseña del admin por defecto** antes de exponer la aplicación a la red.
+
+---
+
+## 2. Gestión de hosts
+
+Los hosts son las máquinas que Ansible gestionará.
+
+**Añadir un host:**
+
+1. Ve a **Hosts** en el sidebar.
+2. Pulsa **Nuevo host**.
+3. Rellena los campos:
+   - **Nombre**: identificador legible (ej. `servidor-web-01`)
+   - **Dirección**: IP o FQDN (ej. `192.168.1.10`)
+   - **Tipo de SO**: `linux` o `windows`
+   - **Tipo de conexión**: `ssh` (Linux) o `winrm` (Windows)
+   - **Puerto**: déjalo en blanco para usar el predeterminado (22 para SSH, 5985 para WinRM)
+   - **Tags**: etiquetas libres para filtrar (ej. `web`, `produccion`)
+4. Pulsa **Crear**.
+
+**Editar o desactivar**: usa el botón de edición en la fila del host. Desactivar un host lo excluye de inventarios futuros pero no elimina los datos.
+
+---
+
+## 3. Inventarios
+
+Un inventario agrupa hosts sobre los que ejecutar un playbook.
+
+**Crear un inventario:**
+
+1. Ve a **Inventarios** en el sidebar.
+2. Pulsa **Nuevo inventario**.
+3. Pon un nombre descriptivo (ej. `servidores-web`).
+4. Selecciona los hosts que forman parte de este inventario.
+5. Pulsa **Crear**.
+
+Puedes editar el inventario en cualquier momento para añadir o quitar hosts.
+
+---
+
+## 4. Credenciales
+
+Las credenciales se cifran con Fernet antes de guardarse. El secreto nunca se muestra tras la creación.
+
+**Tipos de credencial:**
+
+| Tipo | Uso | Campos necesarios |
+|------|-----|-------------------|
+| `ssh_key` | Clave privada SSH | usuario + clave privada + passphrase (opcional) |
+| `ssh_password` | Contraseña SSH | usuario + password |
+| `winrm` | Windows Remote Management | usuario + password |
+
+**Añadir una credencial:**
+
+1. Ve a **Credenciales** en el sidebar.
+2. Pulsa **Nueva credencial**.
+3. Selecciona el tipo y rellena los campos. El campo **Secreto** es la clave privada o password.
+4. Pulsa **Crear**.
+
+> Las credenciales no se asocian directamente a hosts en el MVP; se usan en el inventario generado para Ansible. En una versión futura se podrá asignar credencial por host.
+
+---
+
+## 5. Lanzar un job
+
+Un job es una ejecución de un playbook Ansible contra un inventario.
+
+**Desde la interfaz:**
+
+1. Ve a **Jobs** en el sidebar.
+2. Pulsa **Lanzar job**.
+3. Selecciona el inventario de destino.
+4. Escribe la ruta absoluta del playbook dentro del contenedor (ej. `/opt/playbooks/ping.yml`).
+5. Pulsa **Lanzar**.
+
+El job pasa por los estados: `pending` → `running` → `success` / `failed`.
+
+**Desde la API:**
+
+```bash
+curl -X POST http://localhost/api/jobs \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"inventory_id": "<uuid>", "playbook_path": "/opt/playbooks/ping.yml"}'
+```
+
+---
+
+## 6. Ver logs en tiempo real
+
+Al hacer clic en un job con estado `running` o `pending`, se abre la vista de detalle con un terminal que muestra el stdout de Ansible línea a línea.
+
+- La conexión es un WebSocket; no hace falta recargar la página.
+- Si el job ya terminó, se muestra el stdout completo almacenado.
+- El botón de volver lleva de nuevo a la lista de jobs.
+
+---
+
+## 7. Programar ejecuciones
+
+Los schedules ejecutan playbooks automáticamente según una expresión cron.
+
+**Crear un schedule:**
+
+1. Ve a **Schedules** en el sidebar.
+2. Pulsa **Nuevo schedule**.
+3. Rellena:
+   - **Nombre**: identificador único (ej. `backup-diario`)
+   - **Expresión cron**: 5 campos — `minuto hora día mes día_semana`
+   - **Inventario**: dónde ejecutar el playbook
+   - **Ruta del playbook**: ruta absoluta dentro del contenedor
+   - **Habilitado**: activa o desactiva al crear
+4. Pulsa **Crear**.
+
+**Ejemplos de expresiones cron:**
+
+| Expresión | Significado |
+|-----------|-------------|
+| `0 2 * * *` | Todos los días a las 02:00 |
+| `*/15 * * * *` | Cada 15 minutos |
+| `0 8 * * 1` | Todos los lunes a las 08:00 |
+| `0 0 1 * *` | El primer día de cada mes a las 00:00 |
+
+**Activar / desactivar**: haz clic en el badge **Activo** / **Inactivo** de la fila para alternar el estado sin eliminar el schedule.
+
+**Eliminar**: solo administradores. El schedule se desregistra de Celery Beat automáticamente.
+
+---
+
+## 8. Dashboard
+
+El Dashboard muestra el estado global del sistema en tiempo real.
+
+| Métrica | Descripción |
+|---------|-------------|
+| **Hosts** | Total de hosts registrados |
+| **Inventarios** | Total de inventarios |
+| **Schedules** | Total de schedules configurados |
+| **Jobs totales** | Todos los jobs en historial |
+| **Jobs activos** | Jobs con estado `running` en este momento |
+| **Fallos (24h)** | Jobs fallidos en las últimas 24 horas |
+
+La tabla inferior muestra los **10 jobs más recientes** con enlace al detalle de cada uno.
+
+La vista se recarga automáticamente cada 30 segundos.
+
+---
+
+## 9. Gestión de usuarios
+
+Solo los administradores pueden crear usuarios. Accede a la API directamente:
+
+```bash
+# Crear un operador
+curl -X POST http://localhost/api/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "operador@empresa.com", "password": "password123", "role": "operator"}'
+
+# Crear un viewer (solo lectura)
+curl -X POST http://localhost/api/users \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "auditor@empresa.com", "password": "password123", "role": "viewer"}'
+```
+
+---
+
+## 10. Roles y permisos
+
+| Acción | viewer | operator | admin |
+|--------|:------:|:--------:|:-----:|
+| Ver hosts, inventarios, credenciales | ✓ | ✓ | ✓ |
+| Ver jobs y schedules | ✓ | ✓ | ✓ |
+| Ver dashboard | ✓ | ✓ | ✓ |
+| Crear/editar hosts, inventarios, credenciales | — | ✓ | ✓ |
+| Lanzar jobs | — | ✓ | ✓ |
+| Crear/editar schedules | — | ✓ | ✓ |
+| Eliminar cualquier recurso | — | — | ✓ |
+| Crear usuarios | — | — | ✓ |


### PR DESCRIPTION
## Resumen

- `README.md`: badge de versión, tabla de funcionalidades, variables de entorno documentadas, tabla de puertos dev, estado v0.4.0
- `docs/api.md`: referencia completa de todos los endpoints (auth, users, hosts, inventories, credentials, jobs, schedules, dashboard, WebSocket) con ejemplos curl y tabla de errores
- `docs/user-guide.md`: guía de 10 secciones para administradores — primer acceso, gestión de recursos, lanzar jobs, schedules, dashboard, roles y permisos

## Test plan

- [ ] Verificar que los enlaces del README apuntan a los archivos correctos
- [ ] Revisar que los ejemplos curl de api.md coinciden con los endpoints reales
- [ ] Confirmar tabla de roles en user-guide.md contra el código

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)