### PR TITLE
feat(frontend): paginación en Jobs y Schedules, recarga Dashboard — issue #30

### DIFF
--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -3,8 +3,8 @@ import type { Job, JobCreate, JobDetail } from '@/types'
 
 const base = '/api/jobs'
 
-export async function listJobs(): Promise<Job[]> {
-  const { data } = await axios.get<Job[]>(base)
+export async function listJobs(skip = 0, limit = 20): Promise<Job[]> {
+  const { data } = await axios.get<Job[]>(base, { params: { skip, limit } })
   return data
 }
 

--- a/frontend/src/api/schedules.ts
+++ b/frontend/src/api/schedules.ts
@@ -3,8 +3,8 @@ import type { Schedule, ScheduleCreate, ScheduleUpdate } from '@/types'
 
 const base = '/api/schedules'
 
-export async function listSchedules(): Promise<Schedule[]> {
-  const { data } = await axios.get<Schedule[]>(base)
+export async function listSchedules(skip = 0, limit = 20): Promise<Schedule[]> {
+  const { data } = await axios.get<Schedule[]>(base, { params: { skip, limit } })
   return data
 }
 

--- a/frontend/src/stores/jobs.ts
+++ b/frontend/src/stores/jobs.ts
@@ -3,20 +3,39 @@ import { ref } from 'vue'
 import { listJobs, getJob, createJob, deleteJob } from '@/api/jobs'
 import type { Job, JobCreate, JobDetail } from '@/types'
 
+const PAGE_SIZE = 20
+
 export const useJobsStore = defineStore('jobs', () => {
   const jobs = ref<Job[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const page = ref(0)
+  const hasMore = ref(true)
 
-  async function fetchJobs() {
+  async function fetchJobs(resetPage = true) {
+    if (resetPage) page.value = 0
     loading.value = true
     error.value = null
     try {
-      jobs.value = await listJobs()
+      const result = await listJobs(page.value * PAGE_SIZE, PAGE_SIZE)
+      jobs.value = result
+      hasMore.value = result.length === PAGE_SIZE
     } catch {
       error.value = 'Error al cargar los jobs'
     } finally {
       loading.value = false
+    }
+  }
+
+  async function nextPage() {
+    page.value++
+    await fetchJobs(false)
+  }
+
+  async function prevPage() {
+    if (page.value > 0) {
+      page.value--
+      await fetchJobs(false)
     }
   }
 
@@ -44,5 +63,5 @@ export const useJobsStore = defineStore('jobs', () => {
     jobs.value = jobs.value.filter((j) => j.id !== id)
   }
 
-  return { jobs, loading, error, fetchJobs, fetchJob, launchJob, removeJob }
+  return { jobs, loading, error, page, hasMore, fetchJobs, nextPage, prevPage, fetchJob, launchJob, removeJob }
 })

--- a/frontend/src/stores/schedules.ts
+++ b/frontend/src/stores/schedules.ts
@@ -8,20 +8,39 @@ import {
 } from '@/api/schedules'
 import type { Schedule, ScheduleCreate } from '@/types'
 
+const PAGE_SIZE = 20
+
 export const useSchedulesStore = defineStore('schedules', () => {
   const schedules = ref<Schedule[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const page = ref(0)
+  const hasMore = ref(true)
 
-  async function fetchAll() {
+  async function fetchAll(resetPage = true) {
+    if (resetPage) page.value = 0
     loading.value = true
     error.value = null
     try {
-      schedules.value = await listSchedules()
+      const result = await listSchedules(page.value * PAGE_SIZE, PAGE_SIZE)
+      schedules.value = result
+      hasMore.value = result.length === PAGE_SIZE
     } catch {
       error.value = 'Error al cargar los schedules'
     } finally {
       loading.value = false
+    }
+  }
+
+  async function nextPage() {
+    page.value++
+    await fetchAll(false)
+  }
+
+  async function prevPage() {
+    if (page.value > 0) {
+      page.value--
+      await fetchAll(false)
     }
   }
 
@@ -57,5 +76,5 @@ export const useSchedulesStore = defineStore('schedules', () => {
     schedules.value = schedules.value.filter((s) => s.id !== id)
   }
 
-  return { schedules, loading, error, fetchAll, addSchedule, toggleEnabled, removeSchedule }
+  return { schedules, loading, error, page, hasMore, fetchAll, nextPage, prevPage, addSchedule, toggleEnabled, removeSchedule }
 })

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDashboardStore } from '@/stores/dashboard'
 import JobStatusBadge from '@/components/JobStatusBadge.vue'
@@ -7,7 +7,16 @@ import JobStatusBadge from '@/components/JobStatusBadge.vue'
 const router = useRouter()
 const dashboardStore = useDashboardStore()
 
-onMounted(() => dashboardStore.fetchStats())
+let reloadTimer: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  dashboardStore.fetchStats()
+  reloadTimer = setInterval(() => dashboardStore.fetchStats(), 30_000)
+})
+
+onUnmounted(() => {
+  if (reloadTimer !== null) clearInterval(reloadTimer)
+})
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString('es-ES', { dateStyle: 'short', timeStyle: 'short' })

--- a/frontend/src/views/JobsView.vue
+++ b/frontend/src/views/JobsView.vue
@@ -182,6 +182,27 @@ function formatDate(iso: string): string {
       </table>
     </div>
 
+    <!-- Pagination -->
+    <div v-if="!jobsStore.loading && jobsStore.jobs.length" class="flex items-center justify-between mt-4 text-sm text-gray-500">
+      <span>Página {{ jobsStore.page + 1 }}</span>
+      <div class="flex gap-2">
+        <button
+          :disabled="jobsStore.page === 0"
+          class="px-3 py-1 rounded border border-gray-800 hover:border-gray-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          @click="jobsStore.prevPage()"
+        >
+          ← Anterior
+        </button>
+        <button
+          :disabled="!jobsStore.hasMore"
+          class="px-3 py-1 rounded border border-gray-800 hover:border-gray-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          @click="jobsStore.nextPage()"
+        >
+          Siguiente →
+        </button>
+      </div>
+    </div>
+
     <!-- Confirm delete modal -->
     <ConfirmModal
       :open="jobToDelete !== null"

--- a/frontend/src/views/SchedulesView.vue
+++ b/frontend/src/views/SchedulesView.vue
@@ -239,6 +239,27 @@ const isAdmin = auth.user?.role === 'admin'
       </table>
     </div>
 
+    <!-- Pagination -->
+    <div v-if="!schedulesStore.loading && schedulesStore.schedules.length" class="flex items-center justify-between mt-4 text-sm text-gray-500">
+      <span>Página {{ schedulesStore.page + 1 }}</span>
+      <div class="flex gap-2">
+        <button
+          :disabled="schedulesStore.page === 0"
+          class="px-3 py-1 rounded border border-gray-800 hover:border-gray-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          @click="schedulesStore.prevPage()"
+        >
+          ← Anterior
+        </button>
+        <button
+          :disabled="!schedulesStore.hasMore"
+          class="px-3 py-1 rounded border border-gray-800 hover:border-gray-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          @click="schedulesStore.nextPage()"
+        >
+          Siguiente →
+        </button>
+      </div>
+    </div>
+
     <!-- Confirm delete -->
     <ConfirmModal
       :open="scheduleToDelete !== null"


### PR DESCRIPTION
## Resumen

- `api/jobs.ts` y `api/schedules.ts`: parámetros `skip`/`limit` en `listJobs`/`listSchedules`
- `stores/jobs.ts` y `stores/schedules.ts`: estado `page`/`hasMore`, métodos `nextPage`/`prevPage`
- `JobsView.vue`: controles prev/next con indicador de página actual (20 jobs por página)
- `SchedulesView.vue`: idem para schedules (20 por página)
- `DashboardView.vue`: `setInterval` cada 30s con limpieza en `onUnmounted`

## Test plan

- [ ] Con más de 20 jobs, verificar que prev/next navegan correctamente
- [ ] En página 1 → botón "Anterior" desactivado; en última página → "Siguiente" desactivado
- [ ] Dashboard: esperar 30s y comprobar que las métricas se actualizan sin recargar

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)